### PR TITLE
Add basic project wiki

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Project Wiki
+
+Welcome to the project wiki. Navigate using the links below:
+
+- [Best Practices for Coding with Codex](best_practices_coding_with_codex.md)
+- [How to Add Wiki Articles](adding_wiki_articles.md)
+- [Wiki Article Template](wiki_article_template.md)

--- a/docs/adding_wiki_articles.md
+++ b/docs/adding_wiki_articles.md
@@ -1,0 +1,8 @@
+# How to Add Wiki Articles
+
+To contribute new articles to this wiki:
+
+1. Create a Markdown file in the `docs` directory. Use a short, descriptive file name with dashes or underscores.
+2. Add a link to the new file in `docs/README.md` to keep the table of contents up to date.
+3. Commit the new file and updated `README.md` in a single pull request.
+4. Keep articles concise and use Markdown headings to structure content.

--- a/docs/best_practices_coding_with_codex.md
+++ b/docs/best_practices_coding_with_codex.md
@@ -1,0 +1,9 @@
+# Best Practices for Coding with Codex
+
+Follow these guidelines when working with Codex or other LLM-based tools:
+
+1. **Understand the context.** Read existing docs and comments to ensure new code fits the project.
+2. **Prefer small, testable units of code.** Break functionality into functions or classes with clear responsibilities.
+3. **Document your changes.** Include docstrings and update relevant documentation when adding features.
+4. **Run existing tests.** Execute the repository's test suite after making changes.
+5. **Review diffs before committing.** Ensure the generated code does what you intend and remove any unnecessary or unrelated changes.

--- a/docs/wiki_article_template.md
+++ b/docs/wiki_article_template.md
@@ -1,0 +1,11 @@
+# Article Title
+
+_A brief introductory paragraph._
+
+## Section 1
+
+Write the first section of your article here.
+
+## Section 2
+
+Add more details or examples in additional sections as needed.


### PR DESCRIPTION
## Summary
- create `/docs` directory for a simple markdown-based wiki
- document best practices for coding with Codex
- explain how to add more wiki articles
- provide a wiki article template
- link everything together in `docs/README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bc8af8188323b96c6d0a6d20e90b