### PR TITLE
Implement Simulation core loop with tests

### DIFF
--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.main import Simulation, Event
+
+
+class RecorderEvent(Event):
+    def __init__(self, label, log):
+        self.label = label
+        self.log = log
+
+    def execute(self, sim):
+        self.log.append((self.label, sim.current_time))
+        return []
+
+
+def test_events_execute_in_time_order():
+    log = []
+    sim = Simulation()
+    sim.schedule(RecorderEvent('e1', log), 5)
+    sim.schedule(RecorderEvent('e2', log), 1)
+    sim.schedule(RecorderEvent('e3', log), 3)
+    sim.run()
+    assert [label for label, _ in log] == ['e2', 'e3', 'e1']
+    assert [time for _, time in log] == [1, 3, 5]
+
+
+def test_tied_events_preserve_insertion_order():
+    log = []
+    sim = Simulation()
+    sim.schedule(RecorderEvent('first', log), 2)
+    sim.schedule(RecorderEvent('second', log), 2)
+    sim.run()
+    assert [label for label, _ in log] == ['first', 'second']
+    assert [time for _, time in log] == [2, 2]


### PR DESCRIPTION
## Summary
- develop the `Simulation` class to manage event queue
- use `heapq` with a tie‐breaker counter
- implement `schedule` and `run` methods
- add unit tests for event ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c9589e988323b1c18f2a17b1ad92