### PR TITLE
Add event class implementation prompt

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -3,6 +3,7 @@
 ## Prompt Articles
 - [Prompt0 Dev Init Class](prompt0_dev_init_class.md)
 - [Prompt1 Implement Lift](prompt1_implement_lift.md)
+- [Prompt2 Event Classes](prompt2_event_classes.md)
 
 ## Articles
 - [Adding Wiki Articles](adding_wiki_articles.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,4 @@ Welcome to the project wiki. Navigate using the links below:
 - [Best Practices Coding With Codex](best_practices_coding_with_codex.md)
 - [Law Simulation Book](law_simulation_book.md)
 - [Wiki Article Template](wiki_article_template.md)
+- [Prompt2 Event Classes](prompt2_event_classes.md)

--- a/docs/prompt2_event_classes.md
+++ b/docs/prompt2_event_classes.md
@@ -1,0 +1,40 @@
+random codname:
+
+```copy
+buoyant-yeti 9463ae29
+```
+
+***
+
+# Prompt for Codex prompt2 – Follow-up to "ruthless-ladder 3238db4e"
+
+Implement the event classes in `zero_liftsim/main.py`. `Simulation` and `Lift` are already functioning; `Event`, `ArrivalEvent`, `BoardingEvent`, and `ReturnEvent` are currently only placeholders. Expand them so the simulator can run a basic cycle of arrival, boarding, and lift return.
+
+## Base `Event`
+- Define an abstract class with an `execute(simulation)` method.
+- Document that subclasses must override `execute` and may return an iterable of `(event, time)` pairs to schedule additional events.
+
+## `ArrivalEvent`
+- Store references to an `Agent` and a `Lift`.
+- `execute` should enqueue the agent on the lift.
+- If the lift is idle when the agent arrives, schedule a `BoardingEvent` at the same timestamp.
+
+## `BoardingEvent`
+- Holds a reference to the `Lift`.
+- When executed, call `lift.load()` to board waiting agents.
+- If any agents board, schedule a `ReturnEvent` for `simulation.current_time + lift.cycle_time`.
+
+## `ReturnEvent`
+- Holds a reference to the `Lift`.
+- When executed, call `lift.mark_idle()`.
+- If the queue still contains agents, immediately schedule another `BoardingEvent`.
+
+## Docstrings & Best Practices
+- Provide clear docstrings for each class and method.
+- Follow `docs/best_practices_coding_with_codex.md` for style and small, testable units.
+
+## Tests
+- Add unit tests covering an agent arriving, boarding, and the lift returning using the `Simulation` engine.
+- Ensure the lift state transitions from `idle` → `moving` → `idle` and that events execute in order.
+- Run `pytest` to confirm all tests pass before committing.
+


### PR DESCRIPTION
## Summary
- add instructions for implementing Event subclasses
- update docs table of contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684962a0f3e08323bbd1d80e7bf69a98