### PR TITLE
Add Main Notes section to docs TOC

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -1,16 +1,19 @@
 # Table of Contents
 
+## Main Notes
+- [Dev Notes - Zero Lift Simulator](main_notes_implementation.md)
+
 ## Prompt Articles
-- [Prompt0 Dev Init Class](prompt0_dev_init_class.md)
-- [Prompt1 Implement Lift](prompt1_implement_lift.md)
-- [Prompt2 Event Classes](prompt2_event_classes.md)
-- [Prompt3 Agent Class](prompt3_agent_class.md)
+- [random codname:](prompt0_dev_init_class.md)
+- [random codname:](prompt1_implement_lift.md)
+- [random codname:](prompt2_event_classes.md)
+- [random codname:](prompt3_agent_class.md)
 
 ## Articles
-- [Adding Wiki Articles](adding_wiki_articles.md)
-- [Best Practices Coding With Codex](best_practices_coding_with_codex.md)
+- [How to Add Wiki Articles](adding_wiki_articles.md)
+- [Best Practices for Coding with Codex](best_practices_coding_with_codex.md)
 - [Dev Snippets](dev_snippets.md)
-- [Devplan Capable Push 34Aa005B](devplan-capable-push-34aa005b.md)
-- [Law Simulation Book](law_simulation_book.md)
-- [Main Notes Implementation](main_notes_implementation.md)
-- [Wiki Article Template](wiki_article_template.md)
+- [capable-push](devplan-capable-push-34aa005b.md)
+- [LiftSim Flowchart](flowchart.md)
+- [Simulation Modeling Book Notes](law_simulation_book.md)
+- [Article Title](wiki_article_template.md)

--- a/zero_liftsim/dev.py
+++ b/zero_liftsim/dev.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 
 
+
+def _title_from_file(path: Path) -> str:
+    """Return the first non-empty line of ``path`` stripped of Markdown heading marks."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped.lstrip("#").strip()
+    return ""
+
 def _title_from_filename(name: str) -> str:
     base = Path(name).stem
     base = base.replace("_", " ").replace("-", " ")
@@ -14,6 +23,7 @@ def _title_from_filename(name: str) -> str:
 def generate_docs_toc() -> str:
     """Generate a Markdown table of contents for Markdown files in ``docs``."""
     docs_dir = Path(__file__).resolve().parent.parent / "docs"
+    main_paths: list[Path] = sorted(docs_dir.glob("main_notes*md"))
     prompt_paths: list[Path] = []
     other_paths: list[Path] = []
 
@@ -21,22 +31,33 @@ def generate_docs_toc() -> str:
         name = path.name.lower()
         if name in {"readme.md", "contents.md"}:
             continue
+        if path in main_paths:
+            continue
         if path.stem.lower().startswith("prompt"):
             prompt_paths.append(path)
         else:
             other_paths.append(path)
 
     lines = []
+    lines.append("## Main Notes")
+    if main_paths:
+        for path in main_paths:
+            title = _title_from_file(path)
+            lines.append(f"- [{title}]({path.name})")
+        lines.append("")
+    else:
+        lines.append("- Place files named `main_notes*.md` in the docs folder to include them here.")
+        lines.append("")
     if prompt_paths:
         lines.append("## Prompt Articles")
         for path in prompt_paths:
-            title = _title_from_filename(path.name)
+            title = _title_from_file(path)
             lines.append(f"- [{title}]({path.name})")
         lines.append("")
 
     lines.append("## Articles")
     for path in other_paths:
-        title = _title_from_filename(path.name)
+        title = _title_from_file(path)
         lines.append(f"- [{title}]({path.name})")
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- allow docs TOC generation to include a new **Main Notes** section
- read titles from the first non-empty line of each doc
- regenerate `docs/CONTENTS.md` with the new logic

## Testing
- `pytest -q`
- `python -m zero_liftsim.cli dev --update-toc`


------
https://chatgpt.com/codex/tasks/task_e_6849a395505c83238e27e14f65896828