### PR TITLE
Implement wandering-marmot agent class

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.main import Agent
+
+
+def test_wait_and_finish_ride():
+    agent = Agent(1)
+    agent.start_wait(0)
+    agent.boarded = True
+    wait = agent.finish_ride(5)
+    assert wait == 5
+    assert agent.rides_completed == 1
+    assert not agent.boarded
+
+
+def test_multiple_rides():
+    agent = Agent(2)
+    agent.start_wait(0)
+    agent.boarded = True
+    wait1 = agent.finish_ride(3)
+    assert wait1 == 3
+    assert agent.rides_completed == 1
+
+    agent.start_wait(10)
+    agent.boarded = True
+    wait2 = agent.finish_ride(15)
+    assert wait2 == 5
+    assert agent.rides_completed == 2
+

--- a/zero_liftsim/main.py
+++ b/zero_liftsim/main.py
@@ -158,17 +158,52 @@ class Event:
 
 
 class Agent:
-    """dummy: Represents a skier agent with simple state used during simulation.
+    """Represents a skier and their evolving state during the simulation.
 
     Parameters
     ----------
     agent_id:
         Unique identifier for the agent.
+
+    Notes
+    -----
+    Agents track when they start waiting for the lift, the time they board,
+    and how many rides they have completed. ``start_wait`` and ``finish_ride``
+    update this state so statistics can be gathered over the course of a day.
     """
 
     def __init__(self, agent_id: int) -> None:
         self.agent_id = agent_id
         self.boarded: bool = False
+        self.wait_start: int | None = None
+        self.board_time: int | None = None
+        self.rides_completed: int = 0
+
+    def start_wait(self, time: int) -> None:
+        """Record the time the agent begins waiting in the queue."""
+
+        self.wait_start = time
+
+    def finish_ride(self, time: int) -> int:
+        """Mark the current ride complete and return the wait time.
+
+        Parameters
+        ----------
+        time:
+            Timestamp when the ride finishes.
+
+        Returns
+        -------
+        int
+            The wait time experienced for this ride.
+        """
+
+        wait_start = self.wait_start if self.wait_start is not None else time
+        wait_time = time - wait_start
+        self.rides_completed += 1
+        self.boarded = False
+        self.wait_start = None
+        return wait_time
 
     def __repr__(self) -> str:  # pragma: no cover - convenience
         return f"Agent({self.agent_id})"


### PR DESCRIPTION
## Summary
- expand `Agent` with fields for wait and ride tracking
- add methods to start waiting and finish a ride
- include tests for agent wait time and ride counting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a4f3e1c88323907f3196ceae9e69