### PR TITLE
Implement alpha sim and logging

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -20,3 +20,4 @@
 - [Simulation Modeling Book Notes](law_simulation_book.md)
 - [.. _format:](numpydoc_styleguide.md)
 - [Article Title](wiki_article_template.md)
+- [Running the Alpha Simulation](alpha_sim_usage.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@ Welcome to the project wiki. Navigate using the links below:
 - [Prompt3 Agent Class](prompt3_agent_class.md)
 - [Prompt4 Alpha Simulation and Logging](prompt4_implement_alpha_sim.md)
 - [Checkpoint - Primary Classes Implemented - pink-walk](main_notes_checkpoint_prim_classes.md)
+- [Running the Alpha Simulation](alpha_sim_usage.md)

--- a/docs/alpha_sim_usage.md
+++ b/docs/alpha_sim_usage.md
@@ -1,0 +1,35 @@
+# Running the Alpha Simulation
+
+The alpha simulation provides a quick demonstration of the lift engine.
+Use `run_alpha_sim` to execute a short run and gather basic metrics.
+
+```python
+from zero_liftsim.main import run_alpha_sim
+
+summary = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
+print(summary)
+```
+
+`summary` contains the total number of rides processed and the average
+wait time before boarding.
+
+## Logging Events
+
+The `Simulation.run` method accepts an optional `Logger` instance. This
+captures the event name, timestamp and queue length before each event
+executes.
+
+```python
+from zero_liftsim.logging import Logger
+from zero_liftsim.main import Simulation, Lift, Agent, ArrivalEvent
+
+logger = Logger()
+sim = Simulation()
+lift = Lift(capacity=1, cycle_time=5)
+agent = Agent(1)
+sim.schedule(ArrivalEvent(agent, lift), 0)
+sim.run(logger=logger)
+print(logger.records())
+```
+
+Logs are kept in memory and can be inspected after the run.

--- a/tests/test_alpha_sim.py
+++ b/tests/test_alpha_sim.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.main import run_alpha_sim, Simulation, Lift, Agent, ArrivalEvent, BoardingEvent, ReturnEvent
+from zero_liftsim.logging import Logger
+
+
+def test_run_alpha_sim_metrics():
+    result = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
+    assert result["total_rides"] == 3
+    assert abs(result["average_wait"] - (0 + 4 + 3) / 3) < 1e-6
+
+
+def test_logging_records_events():
+    logger = Logger()
+    sim = Simulation()
+    lift = Lift(capacity=1, cycle_time=5)
+    agent = Agent(1)
+    sim.schedule(ArrivalEvent(agent, lift), 0)
+    sim.run(logger=logger)
+    records = logger.records()
+    assert [r["event"] for r in records] == ["ArrivalEvent", "BoardingEvent", "ReturnEvent"]
+    assert [r["time"] for r in records] == [0, 0, 5]
+    assert [r["queue_length"] for r in records] == [0, 1, 0]

--- a/zero_liftsim/logging.py
+++ b/zero_liftsim/logging.py
@@ -1,0 +1,15 @@
+class Logger:
+    """Simple in-memory event logger."""
+
+    def __init__(self) -> None:
+        self._records: list[dict] = []
+
+    def log(self, event_name: str, time: int, **info) -> None:
+        """Record an event with optional metadata."""
+        entry = {"event": event_name, "time": time}
+        entry.update(info)
+        self._records.append(entry)
+
+    def records(self) -> list[dict]:
+        """Return collected log entries."""
+        return list(self._records)


### PR DESCRIPTION
## Summary
- add in-memory logger utility
- expand Simulation.run with optional logging
- record board times during BoardingEvent
- implement `run_alpha_sim` helper
- document alpha sim usage
- test alpha simulation metrics and logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849efb79e2c8323a56fcd6c3c3c03e9