### PR TITLE
Add file logging to Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ ENV/
 .DS_Store
 Thumbs.db
 
+# Log files
+logs/*.log
+

--- a/docs/alpha_sim_usage.md
+++ b/docs/alpha_sim_usage.md
@@ -32,4 +32,13 @@ sim.run(logger=logger)
 print(logger.records())
 ```
 
-Logs are kept in memory and can be inspected after the run.
+Each logged entry is also appended to ``logs/main.log`` by default.
+You can supply a different filename to ``Logger`` and it will be
+created inside the ``logs`` directory:
+
+```python
+logger = Logger("my_run.log")
+```
+
+The ``records()`` method still returns the in-memory list of log
+entries.

--- a/tests/test_alpha_sim.py
+++ b/tests/test_alpha_sim.py
@@ -1,4 +1,5 @@
 import sys
+import json
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -24,3 +25,19 @@ def test_logging_records_events():
     assert [r["event"] for r in records] == ["ArrivalEvent", "BoardingEvent", "ReturnEvent"]
     assert [r["time"] for r in records] == [0, 0, 5]
     assert [r["queue_length"] for r in records] == [0, 1, 0]
+
+
+def test_logger_writes_file(tmp_path):
+    log_name = "test.log"
+    logger = Logger(log_name)
+    sim = Simulation()
+    lift = Lift(capacity=1, cycle_time=5)
+    agent = Agent(1)
+    sim.schedule(ArrivalEvent(agent, lift), 0)
+    sim.run(logger=logger)
+
+    log_path = Path(__file__).resolve().parents[1] / "logs" / log_name
+    assert log_path.exists()
+    with open(log_path, "r", encoding="utf-8") as f:
+        lines = [json.loads(line) for line in f]
+    assert lines == logger.records()

--- a/zero_liftsim/logging.py
+++ b/zero_liftsim/logging.py
@@ -1,15 +1,46 @@
-class Logger:
-    """Simple in-memory event logger."""
+from __future__ import annotations
 
-    def __init__(self) -> None:
+import json
+from pathlib import Path
+
+
+class Logger:
+    """Simple event logger that writes to a file and keeps entries in memory."""
+
+    def __init__(self, filename: str = "main.log") -> None:
+        """Create a new logger.
+
+        Parameters
+        ----------
+        filename:
+            Name of the log file inside the ``logs`` directory. The directory
+            is created if it does not already exist.
+        """
+
         self._records: list[dict] = []
 
+        logs_dir = Path(__file__).resolve().parents[1] / "logs"
+        logs_dir.mkdir(exist_ok=True)
+        self._path = logs_dir / filename
+        # open in append mode so consecutive runs keep history
+        self._file = open(self._path, "a", encoding="utf-8")
+
     def log(self, event_name: str, time: int, **info) -> None:
-        """Record an event with optional metadata."""
+        """Record an event with optional metadata and write it to file."""
+
         entry = {"event": event_name, "time": time}
         entry.update(info)
         self._records.append(entry)
 
+        self._file.write(json.dumps(entry) + "\n")
+        self._file.flush()
+
     def records(self) -> list[dict]:
         """Return collected log entries."""
         return list(self._records)
+
+    def __del__(self) -> None:
+        try:
+            self._file.close()
+        except AttributeError:
+            pass


### PR DESCRIPTION
## Summary
- implement file-based Logger that defaults to `logs/main.log`
- document new logging behavior
- test log file creation
- ignore generated log files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f3ec582083238a8cbbccdec6a4bc