### PR TITLE
Fix logger file overwrite and add docs

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -18,6 +18,7 @@
 - [Running the Alpha Simulation](alpha_sim_usage.md)
 - [Best Practices for Coding with Codex](best_practices_coding_with_codex.md)
 - [Bugfix with Logger Filepath](bugfix_logger_filepath_finish.md)
+- [Bugfix Response for Logger Filepath](bugfix_response_logger_filepath_finish.md)
 - [Dev Snippets](dev_snippets.md)
 - [Docstring Style Guide](docstring_style_guide.md)
 - [Simulation Modeling Book Notes](law_simulation_book.md)

--- a/docs/bugfix_response_logger_filepath_finish.md
+++ b/docs/bugfix_response_logger_filepath_finish.md
@@ -1,0 +1,11 @@
+# Logger Filepath Bugfix Response
+
+In `tests/test_alpha_sim.py::test_logger_writes_file`, the assertion failed
+because the log file retained entries from earlier runs. The `Logger` class
+opened the log file in append mode, so previous contents persisted between
+executions. When the test compared the on-disk records to `logger.records()`,
+the file contained additional lines and the equality check failed.
+
+The fix updates `Logger.__init__` to open the target log file in write mode.
+Starting with an empty file ensures that the in-memory records match the
+contents written to disk for each run.

--- a/zero_liftsim/logging.py
+++ b/zero_liftsim/logging.py
@@ -22,8 +22,8 @@ class Logger:
         logs_dir = Path(__file__).resolve().parents[1] / "logs"
         logs_dir.mkdir(exist_ok=True)
         self._path = logs_dir / filename
-        # open in append mode so consecutive runs keep history
-        self._file = open(self._path, "a", encoding="utf-8")
+        # open in write mode so each run starts with a clean log file
+        self._file = open(self._path, "w", encoding="utf-8")
 
     def log(self, event_name: str, time: int, **info) -> None:
         """Record an event with optional metadata and write it to file."""


### PR DESCRIPTION
## Summary
- ensure Logger overwrites log file on each run
- document the logger bug and fix
- list the response doc in the docs contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2c1dfb5883239a693494364bf077