### PR TITLE
Add devlog method

### DIFF
--- a/docs/alpha_sim_usage.md
+++ b/docs/alpha_sim_usage.md
@@ -42,3 +42,19 @@ logger = Logger("my_run.log")
 
 The ``records()`` method still returns the in-memory list of log
 entries.
+
+## Development Log
+
+Use ``Logger.devlog`` to write ad-hoc messages directly to the log
+file. Each line is prefixed with an ISO timestamp.
+
+```python
+logger = Logger("debug.log")
+logger.devlog("initializing setup")
+```
+
+The file ``logs/debug.log`` will contain a line similar to::
+
+```
+2025-06-19T12:00:00 initializing setup
+```

--- a/tests/test_alpha_sim.py
+++ b/tests/test_alpha_sim.py
@@ -41,3 +41,21 @@ def test_logger_writes_file(tmp_path):
     with open(log_path, "r", encoding="utf-8") as f:
         lines = [json.loads(line) for line in f]
     assert lines == logger.records()
+
+
+def test_devlog_writes_message():
+    log_name = "dev_test.log"
+    logger = Logger(log_name)
+    logger.devlog("hello world")
+
+    log_path = Path(__file__).resolve().parents[1] / "logs" / log_name
+    assert log_path.exists()
+    with open(log_path, "r", encoding="utf-8") as f:
+        line = f.readline().strip()
+    ts, msg = line.split(" ", 1)
+    from datetime import datetime
+
+    # ensure timestamp parses and message matches
+    datetime.fromisoformat(ts)
+    assert msg == "hello world"
+    assert logger.records() == []

--- a/zero_liftsim/logging.py
+++ b/zero_liftsim/logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from datetime import datetime
 
 
 class Logger:
@@ -33,6 +34,24 @@ class Logger:
         self._records.append(entry)
 
         self._file.write(json.dumps(entry) + "\n")
+        self._file.flush()
+
+    def devlog(self, message: str) -> None:
+        """Write a timestamped development message to the log file.
+
+        Parameters
+        ----------
+        message:
+            Arbitrary text to append to the log file.
+
+        Notes
+        -----
+        ``devlog`` only writes to the file; it does not modify
+        :pyattr:`_records`.
+        """
+
+        stamp = datetime.now().isoformat()
+        self._file.write(f"{stamp} {message}\n")
         self._file.flush()
 
     def records(self) -> list[dict]:


### PR DESCRIPTION
## Summary
- add `devlog` to `Logger` for simple timestamped messages
- show example `devlog` usage in the wiki
- test `devlog` writes a timestamped line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2fde76fc8323855914e0c43e176d