### PR TITLE
Add prompt for full agent logging

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -12,6 +12,7 @@
 - [prompt2 - event classes](prompt2_event_classes.md)
 - [prompt3 - agent class](prompt3_agent_class.md)
 - [prompt4 - alpha simulation and logging](prompt4_implement_alpha_sim.md)
+- [prompt5 - full agent logging](prompt5_full_agent_logging.md)
 
 ## Articles
 - [How to Add Wiki Articles](adding_wiki_articles.md)

--- a/docs/prompt5_full_agent_logging.md
+++ b/docs/prompt5_full_agent_logging.md
@@ -1,0 +1,44 @@
+prompt5 - full agent logging
+
+random codname:
+
+```copy
+cosmic-octopus 1f7d9e34
+```
+
+***
+
+# Prompt for Codex prompt5 – Follow-up to "cobalt-sparrow d7dca612"
+
+Implement a comprehensive agent-level logging feature that can be toggled from
+`Simulation.run` via a new boolean argument `full_agent_logging`. When this
+flag is `True`, the simulation should record every event involving an agent to
+`logs/agent.log`. The goal is to reconstruct each agent's actions throughout the
+run.
+
+## Requirements
+
+- Extend `Simulation.run` with an optional `full_agent_logging: bool = False`
+  parameter. When enabled, create or open `logs/agent.log` for writing.
+- Whenever an `Event` executes and it references an `Agent` (directly or
+  indirectly), write a log entry containing at minimum:
+  - the agent's UUID and codename
+  - the event type and a description of what occurred
+  - timestamps and any other contextual data useful to replay the agent's
+    history (e.g., queue length, lift state, wait time, etc.)
+- Design the log format as newline-delimited JSON so it can be parsed easily.
+- The logging should be implemented in a general way—preferably by adding a
+  helper method on the base `Event` class so subclasses can call it when
+  `full_agent_logging` is active.
+- Store the collected entries in memory as well so tests can inspect them.
+- Ensure existing logging to `main.log` (via `Logger`) continues to work.
+
+## Tests
+
+- Add unit tests that run a small simulation with `full_agent_logging=True` and
+  verify that `logs/agent.log` is created and contains entries for each agent
+  event in chronological order.
+- Confirm that simulations run without this flag do not produce the agent log.
+- Follow the guidance in `docs/best_practices_coding_with_codex.md` and run
+  `pytest` before committing.
+


### PR DESCRIPTION
## Summary
- add prompt5 instructions describing new `full_agent_logging` option for the simulator
- update docs table of contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac6303c38832393591512d90a28c1