### PR TITLE
Implement self-logging for agents

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from zero_liftsim.main import Agent
+from zero_liftsim.main import Agent, Simulation, Lift, ArrivalEvent
 
 
 def test_wait_and_finish_ride():
@@ -29,4 +29,23 @@ def test_multiple_rides():
     wait2 = agent.finish_ride(15)
     assert wait2 == 5
     assert agent.rides_completed == 2
+
+
+def test_activity_log_enabled_via_events():
+    sim = Simulation()
+    lift = Lift(capacity=1, cycle_time=5)
+    agent = Agent(3)
+    agent.start_wait(0)
+    sim.schedule(ArrivalEvent(agent, lift), 0)
+    sim.run()
+    events = [entry["event"] for entry in agent.activity_log.values()]
+    assert events == ["start_wait", "arrival", "board", "ride_complete"]
+
+
+def test_activity_log_disabled():
+    agent = Agent(4, self_logging=False)
+    agent.start_wait(0)
+    agent.boarded = True
+    agent.finish_ride(5)
+    assert agent.activity_log == {}
 


### PR DESCRIPTION
## Summary
- add optional per-agent activity logging
- log events during arrival, boarding, returning, waiting, and ride completion
- expand test coverage for agent logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb7c94348323b428cb0c3ae0822f