### PR TITLE
Add research prompt wiki article

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,4 @@ Welcome to the project wiki. Navigate using the links below:
 - [Running the Alpha Simulation](alpha_sim_usage.md)
 
 - [Project Questions](project_questions.md)
+- [Research Prompt: Business Value from LiftSim](business-value-research-prompt.md)

--- a/docs/business-value-research-prompt.md
+++ b/docs/business-value-research-prompt.md
@@ -1,0 +1,39 @@
+# Research Prompt: Business Value from LiftSim
+
+The following prompt is intended for a research-focused chatbot. The goal is to explore how the Zero Lift Simulator can provide measurable business value and to outline future development priorities.
+
+## Objectives
+
+- Determine realistic business scenarios where LiftSim's results could inform decision making.
+- Identify data requirements and metrics that demonstrate economic impact.
+- Recommend extensions to the codebase that unlock new revenue or efficiency gains.
+
+## Research Questions
+
+1. What operational problems faced by ski resorts can be modeled with LiftSim today?
+2. Which key performance indicators should resort managers monitor to maximize profitability or guest satisfaction?
+3. How might simulation outputs influence pricing, staffing, or capital investment decisions?
+4. What additional features or integrations would make LiftSim more useful for strategic planning or marketing analysis?
+
+## Artifacts Available
+
+- Source code and tests in this repository.
+- Design documents under `docs/` describing current architecture and development plan.
+- Example command-line usage in `zero_liftsim/cli.py` and notebooks in the `notebooks/` directory.
+
+## Instructions for the Research Chatbot
+
+1. Review the repository to understand existing capabilities and limitations.
+2. Survey industry literature on ski resort operations and discrete event simulation.
+3. Map LiftSim outputs to potential business decisions, highlighting where additional modules or analytics might be needed.
+4. Prepare a concise report summarizing findings, recommended experiments, and next steps for development.
+
+## Expected Deliverables
+
+- A short briefing that outlines high-value use cases for LiftSim.
+- A list of feature proposals ranked by projected business impact.
+- References to relevant research or case studies from other industries using event-driven simulations for decision support.
+
+## Using the Results
+
+The research report should guide prioritization of future work on LiftSim, ensuring that new functionality aligns with tangible business outcomes. The recommendations will inform both product strategy and technical roadmap planning.


### PR DESCRIPTION
## Summary
- add a wiki article with a prompt for researching business value of LiftSim
- link the new article from the wiki README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adb2a6d308323bc93db682745b840