### PR TITLE
Add documentation analyzer utility

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -29,6 +29,7 @@
 - [Dev Snippets](dev_snippets.md)
 - [Development Reference for Prompts](development_ref_for_prompts.md)
 - [Docstring Style Guide](docstring_style_guide.md)
+- [Git Tools](git-tools.md)
 - [Simulation Modeling Book Notes](law_simulation_book.md)
 - [Project Questions - answered](project_questions_orange.md)
 - [Styleguide for Wiki Articles](styleguide_wiki_articles.md)

--- a/docs/git-tools.md
+++ b/docs/git-tools.md
@@ -1,0 +1,13 @@
+# Git Tools
+
+This project now includes a small utility module for working with the
+repository's history. The command:
+
+```
+zero-liftsim dev --analyze-docs
+```
+
+walks through every Markdown file in the ``docs`` directory and appends
+a summary section to the end of each file. The section records the most
+recent commit hash and the commit date converted to the ``US/Denver``
+time zone. This helps track when documentation was last updated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ description = "Zero Lift Simulator CLI"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "codenamize>=2.3"
+    "codenamize>=2.3",
+    "GitPython>=3.1",
 ]
 
 [project.scripts]

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.git_tools import last_commit_info
+from zero_liftsim.cli import build_parser
+
+
+def test_last_commit_info_returns_data():
+    path = Path(__file__).resolve().parents[1] / "README.md"
+    sha, dt = last_commit_info(path)
+    assert len(sha) >= 7
+    assert dt.tzinfo is not None
+
+
+def test_cli_parses_analyze_docs():
+    parser = build_parser()
+    args = parser.parse_args(["dev", "--analyze-docs"])
+    assert args.analyze_docs

--- a/zero_liftsim/cli.py
+++ b/zero_liftsim/cli.py
@@ -50,6 +50,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Throwaway util for development / testing. "
     )
+    dev.add_argument(
+        "--analyze-docs",
+        action="store_true",
+        help="Append git info to all markdown docs.",
+    )
     return parser
 
 
@@ -72,6 +77,9 @@ def run(args) -> None:
         data = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
         agents = data['agents']
         ########################################################################
+    if getattr(args, "command", None) == "dev" and args.analyze_docs:
+        from . import dev
+        dev.analyze_docs()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/zero_liftsim/dev.py
+++ b/zero_liftsim/dev.py
@@ -73,3 +73,11 @@ def update_toc() -> None:
         fh.write(toc)
         fh.write("\n")
 
+
+def analyze_docs() -> None:
+    """Append git commit info to all Markdown docs."""
+    docs_dir = Path(__file__).resolve().parent.parent / "docs"
+    from .git_tools import append_git_info
+
+    for path in sorted(docs_dir.glob("*.md")):
+        append_git_info(path)

--- a/zero_liftsim/git_tools.py
+++ b/zero_liftsim/git_tools.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Utilities for querying git history."""
+
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from datetime import timezone, timedelta
+
+from git import Repo
+
+
+_REPO = Repo(Path(__file__).resolve().parents[1])
+
+try:
+    DENVER_TZ = ZoneInfo("US/Denver")
+except ZoneInfoNotFoundError:  # pragma: no cover - fallback when tzdata missing
+    DENVER_TZ = timezone(timedelta(hours=-7))
+
+
+def last_commit_info(path: Path) -> tuple[str, datetime]:
+    """Return the last commit SHA and datetime for ``path``.
+
+    Parameters
+    ----------
+    path:
+        File path to inspect. It must be within the project repository.
+    """
+    rel = path.relative_to(_REPO.working_tree_dir)
+    commit = next(_REPO.iter_commits(paths=str(rel), max_count=1))
+    dt = commit.committed_datetime.astimezone(DENVER_TZ)
+    return commit.hexsha, dt
+
+
+def append_git_info(path: Path) -> None:
+    """Append git commit info to ``path`` in place."""
+    sha, dt = last_commit_info(path)
+    text = path.read_text(encoding="utf-8").rstrip() + "\n"
+    lines = text.splitlines()
+    # remove existing Git Info section if present
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].startswith("# Git Info"):
+            lines = lines[:i]
+            break
+    lines.append("# Git Info")
+    lines.append(f"Commit: {sha}")
+    lines.append(f"Date: {dt.isoformat()}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add module to inspect git history and write commit info
- expose `zero-liftsim dev --analyze-docs` option
- implement dev helper to append git info to docs
- document the new git tools
- require GitPython for repo access
- add basic tests for git tools

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b09cca6608323bf224589fa9af4f7