### PR TITLE
Add prompt7 for simulation datetime logging

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -36,7 +36,7 @@
 - [Project Questions stingy-orange - answered](project_questions_orange.md)
 - [Styleguide for Wiki Articles](styleguide_wiki_articles.md)
 - [Prompt Setup for Simulation Time Entries Enhancement](time_tracking_enhancement.md)
-- [unnamed periodic-concentrate 057c30ef](unnamed-periodic-concentrate-057c30ef.md)
+- [prompt7 - simulation datetime logging](prompt7_simulation_datetime.md)
 - [Updating Dependencies](updating_dependencies.md)
 - [Wiki Article Creation Instructions for Codex](wiki_article_creation_for_codex.md)
 - [Article Title](wiki_article_template.md)

--- a/docs/prompt7_simulation_datetime.md
+++ b/docs/prompt7_simulation_datetime.md
@@ -1,0 +1,24 @@
+prompt7 - simulation datetime logging
+
+random codname:
+
+```copy
+hilarious-consist 534ec3a9
+```
+
+***
+
+# Prompt for Codex prompt7 – Follow-up to enhanced time tracking
+
+Analyze the codebase and implement real datetime entries for all logged events. Currently the `Agent.log_event` method and `Logger.log` store an integer `time` representing simulation minutes. The new requirement is to convert these to timestamp strings starting from a configurable simulation start time.
+
+## Requirements
+- Add a `start_datetime` parameter to `Simulation.run` with default `datetime(2025, 3, 12, 9, 0, 0)`.
+- Keep internal simulation times as integers but, whenever an event is logged, convert the minute offset to `start_datetime + timedelta(minutes=time)` and store the ISO formatted string in the log under `time`.
+- `Agent.finish_ride` should also record `wait_time_readable` as `<wait_time> minutes` in the log.
+- Update `Logger.log` and `Agent.log_event` signatures to accept both the numeric offset and the computed timestamp. All existing calls should pass the current simulation time and rely on these methods to format the timestamp.
+- Allow callers of `run_alpha_sim` (and CLI) to optionally specify the start datetime and propagate it to `Simulation.run`.
+
+## Tests
+- Adjust tests to account for the new timestamp format. It is sufficient to verify that `Agent.activity_log` contains ISO formatted `time` strings and that `wait_time_readable` appears on `ride_complete` entries.
+

--- a/docs/unnamed-periodic-concentrate-057c30ef.md
+++ b/docs/unnamed-periodic-concentrate-057c30ef.md
@@ -1,7 +1,0 @@
-# unnamed periodic-concentrate 057c30ef
-
-random codename: periodic-concentrate 057c30ef
-
-***
-
-contenthere


### PR DESCRIPTION
## Summary
- add new prompt doc `prompt7_simulation_datetime.md`
- update table of contents to reference prompt7

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b111f8f748323ade260c2213df49c