### PR TITLE
Fix packaging for pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
 
 [project.scripts]
 zero-liftsim = "zero_liftsim.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["zero_liftsim*"]


### PR DESCRIPTION
## Summary
- ensure setuptools only packages the `zero_liftsim` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0f47b2b48323b7a77440f04eea38