### PR TITLE
Implement datetime logs

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,14 +3,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from datetime import datetime, timedelta
 from zero_liftsim.main import Agent, Simulation, Lift, ArrivalEvent
 
 
 def test_wait_and_finish_ride():
     agent = Agent(1)
-    agent.start_wait(0)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    agent.start_wait(0, start.isoformat())
     agent.boarded = True
-    wait = agent.finish_ride(5)
+    ts = (start + timedelta(minutes=5)).isoformat()
+    wait = agent.finish_ride(5, ts)
     assert wait == 5
     assert agent.rides_completed == 1
     assert not agent.boarded
@@ -18,15 +21,18 @@ def test_wait_and_finish_ride():
 
 def test_multiple_rides():
     agent = Agent(2)
-    agent.start_wait(0)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    agent.start_wait(0, start.isoformat())
     agent.boarded = True
-    wait1 = agent.finish_ride(3)
+    ts1 = (start + timedelta(minutes=3)).isoformat()
+    wait1 = agent.finish_ride(3, ts1)
     assert wait1 == 3
     assert agent.rides_completed == 1
 
-    agent.start_wait(10)
+    agent.start_wait(10, (start + timedelta(minutes=10)).isoformat())
     agent.boarded = True
-    wait2 = agent.finish_ride(15)
+    ts2 = (start + timedelta(minutes=15)).isoformat()
+    wait2 = agent.finish_ride(15, ts2)
     assert wait2 == 5
     assert agent.rides_completed == 2
 
@@ -35,17 +41,22 @@ def test_activity_log_enabled_via_events():
     sim = Simulation()
     lift = Lift(capacity=1, cycle_time=5)
     agent = Agent(3)
-    agent.start_wait(0)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    agent.start_wait(0, start.isoformat())
     sim.schedule(ArrivalEvent(agent, lift), 0)
-    sim.run()
+    sim.run(start_datetime=start)
     events = [entry["event"] for entry in agent.activity_log.values()]
     assert events == ["start_wait", "arrival", "board", "ride_complete"]
+    for entry in agent.activity_log.values():
+        datetime.fromisoformat(entry["time"])
+    assert "wait_time_readable" in agent.activity_log[3]
 
 
 def test_activity_log_disabled():
     agent = Agent(4, self_logging=False)
-    agent.start_wait(0)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    agent.start_wait(0, start.isoformat())
     agent.boarded = True
-    agent.finish_ride(5)
+    agent.finish_ride(5, (start + timedelta(minutes=5)).isoformat())
     assert agent.activity_log == {}
 

--- a/tests/test_alpha_sim.py
+++ b/tests/test_alpha_sim.py
@@ -1,15 +1,27 @@
 import sys
 import json
+from datetime import datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from zero_liftsim.main import run_alpha_sim, Simulation, Lift, Agent, ArrivalEvent, BoardingEvent, ReturnEvent
+from zero_liftsim.main import (
+    run_alpha_sim,
+    Simulation,
+    Lift,
+    Agent,
+    ArrivalEvent,
+    BoardingEvent,
+    ReturnEvent,
+)
 from zero_liftsim.logging import Logger
 
 
 def test_run_alpha_sim_metrics():
-    result = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    result = run_alpha_sim(
+        n_agents=3, lift_capacity=2, cycle_time=5, start_datetime=start
+    )
     assert result["total_rides"] == 3
     assert abs(result["average_wait"] - (0 + 4 + 3) / 3) < 1e-6
 
@@ -20,10 +32,16 @@ def test_logging_records_events():
     lift = Lift(capacity=1, cycle_time=5)
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
-    sim.run(logger=logger)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    sim.run(logger=logger, start_datetime=start)
     records = logger.records()
     assert [r["event"] for r in records] == ["ArrivalEvent", "BoardingEvent", "ReturnEvent"]
-    assert [r["time"] for r in records] == [0, 0, 5]
+    expected_times = [
+        start.isoformat(),
+        start.isoformat(),
+        (start + timedelta(minutes=5)).isoformat(),
+    ]
+    assert [r["time"] for r in records] == expected_times
     assert [r["queue_length"] for r in records] == [0, 1, 0]
 
 
@@ -34,7 +52,8 @@ def test_logger_writes_file(tmp_path):
     lift = Lift(capacity=1, cycle_time=5)
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
-    sim.run(logger=logger)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    sim.run(logger=logger, start_datetime=start)
 
     log_path = Path(__file__).resolve().parents[1] / "logs" / log_name
     assert log_path.exists()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from datetime import datetime
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -33,7 +34,7 @@ def test_single_agent_cycle():
             return events
 
     sim.schedule(LogArrivalEvent(agent, lift), 0)
-    sim.run()
+    sim.run(start_datetime=datetime(2025, 3, 12, 9, 0, 0))
 
     assert log == [
         ("arrival", "idle"),

--- a/tests/test_full_agent_logging.py
+++ b/tests/test_full_agent_logging.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from datetime import datetime
 from zero_liftsim.main import Simulation, Lift, Agent, ArrivalEvent
 
 
@@ -12,7 +13,8 @@ def test_agent_log_created_and_contains_entries():
     lift = Lift(capacity=1, cycle_time=5)
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
-    sim.run(full_agent_logging=True)
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    sim.run(full_agent_logging=True, start_datetime=start)
 
     log_path = Path(__file__).resolve().parents[1] / "logs" / "agent.log"
     assert log_path.exists()
@@ -33,7 +35,7 @@ def test_agent_log_not_created_when_disabled():
     lift = Lift(capacity=1, cycle_time=5)
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
-    sim.run()
+    sim.run(start_datetime=datetime(2025, 3, 12, 9, 0, 0))
 
     assert not log_path.exists()
     assert sim.agent_records() == []

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from datetime import datetime
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -24,7 +25,7 @@ def test_events_execute_in_time_order():
     sim.schedule(RecorderEvent('e1', log), 5)
     sim.schedule(RecorderEvent('e2', log), 1)
     sim.schedule(RecorderEvent('e3', log), 3)
-    sim.run()
+    sim.run(start_datetime=datetime(2025, 3, 12, 9, 0, 0))
     assert [label for label, _ in log] == ['e2', 'e3', 'e1']
     assert [time for _, time in log] == [1, 3, 5]
 
@@ -34,6 +35,6 @@ def test_tied_events_preserve_insertion_order():
     sim = Simulation()
     sim.schedule(RecorderEvent('first', log), 2)
     sim.schedule(RecorderEvent('second', log), 2)
-    sim.run()
+    sim.run(start_datetime=datetime(2025, 3, 12, 9, 0, 0))
     assert [label for label, _ in log] == ['first', 'second']
     assert [time for _, time in log] == [2, 2]

--- a/zero_liftsim/cli.py
+++ b/zero_liftsim/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from datetime import datetime
 
 from zero_liftsim import main as zls, __version__
 
@@ -51,6 +52,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Throwaway util for development / testing. "
     )
     dev.add_argument(
+        "--start-datetime",
+        metavar="ISO",
+        help="Start datetime for dev simulation runs.",
+    )
+    dev.add_argument(
         "--analyze-docs",
         action="store_true",
         help="Append git info to all markdown docs.",
@@ -79,7 +85,17 @@ def run(args) -> None:
         ########################################################################
         import pandas as pd
         from zero_liftsim.main import run_alpha_sim
-        data = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
+        start = (
+            datetime.fromisoformat(args.start_datetime)
+            if args.start_datetime
+            else datetime(2025, 3, 12, 9, 0, 0)
+        )
+        data = run_alpha_sim(
+            n_agents=3,
+            lift_capacity=2,
+            cycle_time=5,
+            start_datetime=start,
+        )
         agents = data['agents']
         ########################################################################
     if getattr(args, "command", None) == "dev" and args.analyze_docs:

--- a/zero_liftsim/logging.py
+++ b/zero_liftsim/logging.py
@@ -26,10 +26,14 @@ class Logger:
         # open in write mode so each run starts with a clean log file
         self._file = open(self._path, "w", encoding="utf-8")
 
-    def log(self, event_name: str, time: int, **info) -> None:
+    def log(self, event_name: str, time: int, timestamp: str, **info) -> None:
         """Record an event with optional metadata and write it to file."""
 
-        entry = {"event": event_name, "time": time}
+        entry = {
+            "event": event_name,
+            "time": timestamp,
+            "time_offset": time,
+        }
         entry.update(info)
         self._records.append(entry)
 


### PR DESCRIPTION
## Summary
- convert logging to use timestamps
- track wait time in minutes
- pass start datetime through CLI and sim helper
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1509d9348323a255c12ccd302b65