### PR TITLE
Add testing article and skip duplicate git info

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -37,6 +37,7 @@
 - [Simulation Modeling Book Notes](law_simulation_book.md)
 - [Project Questions stingy-orange - answered](project_questions_orange.md)
 - [Simulation Motivations](purpose-of-simulation-voice-memo-thankful-examination-e38a3737.md)
+- [Running Tests Using python -m pytest](running_tests.md)
 - [Styleguide for Wiki Articles](styleguide_wiki_articles.md)
 - [Prompt Setup for Simulation Time Entries Enhancement](time_tracking_enhancement.md)
 - [unnamed abiding-fly 31dfaeb0](unnamed-abiding-fly-31dfaeb0.md)
@@ -44,3 +45,6 @@
 - [Updating Dependencies](updating_dependencies.md)
 - [Wiki Article Creation Instructions for Codex](wiki_article_creation_for_codex.md)
 - [Article Title](wiki_article_template.md)
+# Git Info
+Commit: b210bedcf70788d958ecc7a36adfc768f04c4e97
+Date: 2025-06-12T11:23:14-07:00

--- a/docs/running_tests.md
+++ b/docs/running_tests.md
@@ -1,0 +1,18 @@
+# Running Tests Using python -m pytest
+random codename: statuesque-equipment b4d7faf3
+
+***
+
+To ensure `pytest` uses the same interpreter where dependencies are
+installed, invoke it with Python's `-m` flag:
+
+```bash
+python -m pytest
+```
+
+Using `python -m pytest` avoids mismatches between different Python
+executables or virtual environments. Always run tests this way after
+installing packages with `python -m pip install -e .`.
+# Git Info
+Commit: 66d5b5a4a6a39b8c45772909e18d587fcdb780ca
+Date: 2025-06-12T11:28:15-07:00

--- a/docs/unnamed-abiding-fly-31dfaeb0.md
+++ b/docs/unnamed-abiding-fly-31dfaeb0.md
@@ -5,3 +5,6 @@ random codename: abiding-fly 31dfaeb0
 ***
 
 contenthere
+# Git Info
+Commit: b210bedcf70788d958ecc7a36adfc768f04c4e97
+Date: 2025-06-12T11:23:14-07:00

--- a/docs/unnamed-earsplitting-impression-bc7761ee.md
+++ b/docs/unnamed-earsplitting-impression-bc7761ee.md
@@ -5,3 +5,6 @@ random codename: earsplitting-impression bc7761ee
 ***
 
 contenthere
+# Git Info
+Commit: d663168dcd465938fa62c0a28c64785a4892407a
+Date: 2025-06-12T11:20:11-07:00

--- a/docs/updating_dependencies.md
+++ b/docs/updating_dependencies.md
@@ -5,9 +5,10 @@ Follow these steps whenever you need to add or upgrade a library.
 
 1. Edit the `[project]` section of `pyproject.toml` and list the package
    under `dependencies`.
-2. Run `pip install -e .` to install the project along with its updated
+2. Run `python -m pip install -e .` to install the project with its updated
    requirements.
-3. Execute `pytest` to ensure everything works with the new versions.
+3. Execute `python -m pytest` to ensure everything works with the new
+   versions.
 
 Keeping dependencies pinned in version control makes setups reproducible
 and prevents missing package errors like the one shown in `bugfix_add_deps.md`.

--- a/zero_liftsim/dev.py
+++ b/zero_liftsim/dev.py
@@ -80,4 +80,7 @@ def analyze_docs() -> None:
     from .git_tools import append_git_info
 
     for path in sorted(docs_dir.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        if "# Git Info" in text:
+            continue
         append_git_info(path)


### PR DESCRIPTION
## Summary
- document how to run tests with `python -m pytest`
- update dependency instructions to use explicit `python -m` invocations
- ensure `dev --analyze-docs` skips files that already contain Git Info
- regenerate `CONTENTS.md`
- attach Git Info to older wiki articles

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b13f05c1c8323b2d66fe4748a9415