### PR TITLE
Implement agent experience logging

### DIFF
--- a/docs/agent-experience.md
+++ b/docs/agent-experience.md
@@ -1,0 +1,23 @@
+# Agent Experience
+
+The simulation records per-agent ride loop metrics using the
+`AgentExperience` system. Every `Agent` owns an instance of
+`AgentRideLoopExperience` which logs the duration of each stage of a ski
+loop. Durations are sampled from the lift during boarding and when the
+ride completes.
+
+Each entry is keyed by the simulation timestamp (as a `datetime`) and
+contains the sampled ride time, traverse time, and the time spent in the
+queue inferred from arrival and boarding events.
+
+Example logged entry:
+
+```json
+{
+  "2025-03-12T09:15:00": {
+    "time_cost_ride_lift": 7.2,
+    "time_cost_traverse_down_mountain": 5.1,
+    "time_cost_in_queue": 4.6
+  }
+}
+```

--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from uuid import uuid4 as uuid
+from datetime import datetime, timedelta
+
+try:
+    from codenamize import codenamize
+except ModuleNotFoundError:  # pragma: no cover
+    def codenamize(value: str) -> str:
+        return value[:8]
+
+from .logging import Logger
+from .experience import AgentRideLoopExperience
+
+
+class Agent:
+    """Represents an individual skier within the simulation."""
+
+    def __init__(
+        self,
+        agent_id: int,
+        logger: "Logger" | None = None,
+        self_logging: bool = True,
+    ) -> None:
+        self.agent_id = agent_id
+        self.agent_uuid = str(uuid())
+        self.agent_uuid_codename = codenamize(self.agent_uuid)
+        self.boarded: bool = False
+        self.wait_start: int | None = None
+        self.board_time: int | None = None
+        self.rides_completed: int = 0
+        self.self_logging = self_logging
+        self.activity_log: dict[int, dict] = {}
+        self.rideloop = AgentRideLoopExperience()
+        if logger is not None:
+            logger.devlog(
+                f"init agent {self.agent_uuid} {self.agent_uuid_codename}"
+            )
+            self.logger = logger
+
+    def log_event(self, event: str, time: int, timestamp: str, **info) -> None:
+        """Append a record to :pyattr:`activity_log` if self logging is enabled."""
+
+        if not self.self_logging:
+            return
+        record = {
+            "time": timestamp,
+            "time_offset": time,
+            "event": event,
+            "agent_id": self.agent_id,
+            "agent_uuid": self.agent_uuid,
+            "agent_uuid_codename": self.agent_uuid_codename,
+        }
+        record.update(info)
+        self.activity_log[len(self.activity_log)] = record
+
+    def start_wait(self, time: int, timestamp: str) -> None:
+        """Record the time the agent begins waiting in the queue."""
+
+        self.wait_start = time
+        self.log_event("start_wait", time, timestamp)
+
+    def finish_ride(self, time: int, timestamp: str) -> int:
+        """Mark the current ride complete and return the wait time."""
+
+        wait_start = self.wait_start if self.wait_start is not None else time
+        wait_time = time - wait_start
+        self.rides_completed += 1
+        self.boarded = False
+        self.wait_start = None
+        self.log_event(
+            "ride_complete",
+            time,
+            timestamp,
+            wait_time=wait_time,
+            wait_time_readable=f"{wait_time} minutes",
+        )
+        return wait_time
+
+    def __repr__(self) -> str:  # pragma: no cover - convenience
+        return f"Agent({self.agent_id})"

--- a/zero_liftsim/experience.py
+++ b/zero_liftsim/experience.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+class AgentExperience:
+    """Base class for tracking per-agent experience data."""
+
+    def __init__(self) -> None:
+        self.log: dict[datetime, dict] = {}
+
+
+class AgentRideLoopExperience(AgentExperience):
+    """Record time costs for a single ride loop."""
+
+    def add_entry(self, dt: datetime, ride: float, traverse: float, queue: float) -> None:
+        self.log[dt] = {
+            "time_cost_ride_lift": ride,
+            "time_cost_traverse_down_mountain": traverse,
+            "time_cost_in_queue": queue,
+        }


### PR DESCRIPTION
## Summary
- refactor `Agent` into its own module with ride loop experience
- add `AgentExperience` and `AgentRideLoopExperience`
- extend `Lift` with time sampling helpers
- log sampled ride loop data when a ride completes
- document the new agent experience feature

Codename: **spurious-action 9169a44e**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2f458d0c8323a571c6323a14ed2a