### PR TITLE
Introduce SimulationManager class

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -22,6 +22,7 @@
 
 ## Articles
 - [How to Add Wiki Articles](adding_wiki_articles.md)
+- [Agent Experience](agent-experience.md)
 - [Running the Alpha Simulation](alpha_sim_usage.md)
 - [As a Human: How to Code with Codex](as_a_human_how_to_code_with_codex.md)
 - [Best Practices for Coding with Codex](best_practices_coding_with_codex.md)
@@ -35,12 +36,14 @@
 - [Dev Snippets](dev_snippets.md)
 - [Development Reference for Prompts](development_ref_for_prompts.md)
 - [Docstring Style Guide](docstring_style_guide.md)
+- [codex: Maintain SimulationManager Documentation](for_codex_simmanager_docs.md)
 - [codex: Update the Table of Contents](for_codex_update_toc.md)
 - [Git Tools](git-tools.md)
 - [Simulation Modeling Book Notes](law_simulation_book.md)
 - [Project Questions stingy-orange - answered](project_questions_orange.md)
 - [Simulation Motivations](purpose-of-simulation-voice-memo-thankful-examination-e38a3737.md)
 - [Running Tests Using python -m pytest](running_tests.md)
+- [Using SimulationManager](simulation_manager_tutorial.md)
 - [Styleguide for Wiki Articles](styleguide_wiki_articles.md)
 - [Prompt Setup for Simulation Time Entries Enhancement](time_tracking_enhancement.md)
 - [Updating Dependencies](updating_dependencies.md)

--- a/docs/for_codex_simmanager_docs.md
+++ b/docs/for_codex_simmanager_docs.md
@@ -1,0 +1,5 @@
+codex: Maintain SimulationManager Documentation
+
+The tutorial ``simulation_manager_tutorial.md`` and the docstrings
+for ``SimulationManager`` must be kept up to date whenever the class or
+its API changes.

--- a/docs/simulation_manager_tutorial.md
+++ b/docs/simulation_manager_tutorial.md
@@ -1,0 +1,21 @@
+# Using SimulationManager
+random codename: animated-event e6b82433
+***
+The `SimulationManager` class orchestrates configuration and execution
+of a lift simulation. Instantiate it with parameters similar to an
+`sklearn` estimator and call ``run`` to execute the simulation.
+
+```python
+from main.simmanager import SimulationManager
+
+manager = SimulationManager(
+    n_agents=3,
+    lift_capacity=2,
+    cycle_time=5,
+)
+result = manager.run()
+print(result)
+```
+
+The returned dictionary matches ``run_alpha_sim`` but ``SimulationManager``
+exposes additional helpers like :py:meth:`archive_agent_rideloop_experience`.

--- a/main/simmanager.py
+++ b/main/simmanager.py
@@ -1,0 +1,89 @@
+"""High level interface for running lift simulations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime, timedelta
+
+from zero_liftsim.main import (
+    Simulation,
+    Lift,
+    Agent,
+    ArrivalEvent,
+    BoardingEvent,
+    ReturnEvent,
+)
+from zero_liftsim.logging import Logger
+
+
+class SimulationManager:
+    """Configure and execute a lift simulation.
+
+    Parameters
+    ----------
+    n_agents : int
+        Number of agents that will participate in the simulation.
+    lift_capacity : int
+        Number of agents a lift can board per cycle.
+    cycle_time : int
+        Minutes for the lift to complete one round trip.
+    start_datetime : datetime, optional
+        When the simulation begins. Defaults to 2025-03-12 09:00.
+    logger : Logger, optional
+        Logger used during the run. Created automatically if omitted.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_agents: int,
+        lift_capacity: int,
+        cycle_time: int,
+        start_datetime: datetime | None = None,
+        logger: Logger | None = None,
+    ) -> None:
+        self.n_agents = n_agents
+        self.lift_capacity = lift_capacity
+        self.cycle_time = cycle_time
+        self.start_datetime = start_datetime or datetime(2025, 3, 12, 9, 0, 0)
+        self.logger = logger or Logger()
+        self.sim: Simulation | None = None
+        self.lift: Lift | None = None
+        self.agents: list[Agent] = []
+        self.arrival_times: list[int] = []
+
+    def _setup(self) -> None:
+        self.sim = Simulation()
+        self.lift = Lift(self.lift_capacity, self.cycle_time)
+        self.agents = [Agent(i + 1, logger=self.logger) for i in range(self.n_agents)]
+        self.arrival_times = []
+        for i, agent in enumerate(self.agents):
+            self.arrival_times.append(i)
+            ts = (self.start_datetime + timedelta(minutes=i)).isoformat()
+            agent.start_wait(i, ts)
+            self.sim.schedule(ArrivalEvent(agent, self.lift), i)
+
+    def run(self) -> dict:
+        """Execute the simulation and return summary metrics."""
+        if self.sim is None:
+            self._setup()
+        assert self.sim is not None  # mypy hint
+        self.sim.run(logger=self.logger, full_agent_logging=True, start_datetime=self.start_datetime)
+        total_wait = 0
+        for agent, arrive in zip(self.agents, self.arrival_times):
+            if agent.board_time is not None:
+                total_wait += agent.board_time - arrive
+        avg_wait = total_wait / self.n_agents if self.n_agents > 0 else 0
+        return {"total_rides": self.n_agents, "average_wait": avg_wait, "agents": self.agents}
+
+    def archive_agent_rideloop_experience(self, directory: str | Path) -> None:
+        """Write each agent's ride loop log to ``directory`` in JSON format."""
+        path = Path(directory)
+        path.mkdir(parents=True, exist_ok=True)
+        for agent in self.agents:
+            data = {dt.isoformat(): info for dt, info in agent.rideloop.log.items()}
+            outfile = path / f"agent_{agent.agent_id}.json"
+            with outfile.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2)
+

--- a/zero_liftsim/main.py
+++ b/zero_liftsim/main.py
@@ -509,29 +509,13 @@ def run_alpha_sim(
 ) -> dict:
     """Run a minimal simulation and return basic metrics."""
 
-    logger = Logger()
-    sim = Simulation()
-    lift = Lift(lift_capacity, cycle_time)
-    agents = [Agent(i + 1, logger=logger) for i in range(n_agents)]
-    arrival_times: list[int] = []
+    from main.simmanager import SimulationManager
 
-    if start_datetime is None:
-        start_datetime = datetime(2025, 3, 12, 9, 0, 0)
-
-    for i, agent in enumerate(agents):
-        arrival_times.append(i)
-        ts = (start_datetime + timedelta(minutes=i)).isoformat()
-        agent.start_wait(i, ts)
-        sim.schedule(ArrivalEvent(agent, lift), i)
-
-    sim.run(logger=logger, full_agent_logging=True, start_datetime=start_datetime)
-
-    total_wait = 0
-    for agent, arrive in zip(agents, arrival_times):
-        if agent.board_time is not None:
-            total_wait += agent.board_time - arrive
-
-    avg_wait = total_wait / n_agents if n_agents > 0 else 0
-
-    return {"total_rides": n_agents, "average_wait": avg_wait, "agents": agents}
+    manager = SimulationManager(
+        n_agents=n_agents,
+        lift_capacity=lift_capacity,
+        cycle_time=cycle_time,
+        start_datetime=start_datetime,
+    )
+    return manager.run()
 


### PR DESCRIPTION
## Summary
- add `main/simmanager.py` providing `SimulationManager`
- integrate SimulationManager into `run_alpha_sim`
- document SimulationManager usage
- add note directing codex to keep docs and docstrings current
- update table of contents

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3a2ecae8832398e1386ce8425ff8