### PR TITLE
Move Lift to new module and use dynamic cycle time

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -4,7 +4,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from datetime import datetime, timedelta
-from zero_liftsim.main import Agent, Simulation, Lift, ArrivalEvent
+from zero_liftsim.main import Agent, Simulation, ArrivalEvent
+from zero_liftsim.lift import Lift
 
 
 def test_wait_and_finish_ride():
@@ -39,7 +40,8 @@ def test_multiple_rides():
 
 def test_activity_log_enabled_via_events():
     sim = Simulation()
-    lift = Lift(capacity=1, cycle_time=5)
+    lift = Lift(capacity=1)
+    lift.time_spent_ride_lift = lambda: 5
     agent = Agent(3)
     start = datetime(2025, 3, 12, 9, 0, 0)
     agent.start_wait(0, start.isoformat())

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,13 +6,15 @@ from datetime import datetime
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from zero_liftsim.main import Agent, ArrivalEvent, BoardingEvent, ReturnEvent, Lift, Simulation
+from zero_liftsim.main import Agent, ArrivalEvent, BoardingEvent, ReturnEvent, Simulation
+from zero_liftsim.lift import Lift
 
 
 def test_single_agent_cycle():
     log = []
     sim = Simulation()
-    lift = Lift(capacity=1, cycle_time=5)
+    lift = Lift(capacity=1)
+    lift.time_spent_ride_lift = lambda: 5
     agent = Agent(1)
 
     class LogArrivalEvent(ArrivalEvent):

--- a/tests/test_full_agent_logging.py
+++ b/tests/test_full_agent_logging.py
@@ -5,12 +5,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from datetime import datetime
-from zero_liftsim.main import Simulation, Lift, Agent, ArrivalEvent
+from zero_liftsim.main import Simulation, Agent, ArrivalEvent
+from zero_liftsim.lift import Lift
 
 
 def test_agent_log_created_and_contains_entries():
     sim = Simulation()
-    lift = Lift(capacity=1, cycle_time=5)
+    lift = Lift(capacity=1)
+    lift.time_spent_ride_lift = lambda: 5
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
     start = datetime(2025, 3, 12, 9, 0, 0)
@@ -32,7 +34,8 @@ def test_agent_log_not_created_when_disabled():
         log_path.unlink()
 
     sim = Simulation()
-    lift = Lift(capacity=1, cycle_time=5)
+    lift = Lift(capacity=1)
+    lift.time_spent_ride_lift = lambda: 5
     agent = Agent(1)
     sim.schedule(ArrivalEvent(agent, lift), 0)
     sim.run(start_datetime=datetime(2025, 3, 12, 9, 0, 0))

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -5,11 +5,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from zero_liftsim.main import Agent, Lift
+from zero_liftsim.main import Agent
+from zero_liftsim.lift import Lift
 
 
 def test_fifo_loading_and_capacity():
-    lift = Lift(capacity=2, cycle_time=5)
+    lift = Lift(capacity=2)
     a1, a2, a3 = Agent(1), Agent(2), Agent(3)
     lift.enqueue(a1)
     lift.enqueue(a2)
@@ -23,7 +24,7 @@ def test_fifo_loading_and_capacity():
 
 
 def test_state_transitions():
-    lift = Lift(capacity=1, cycle_time=3)
+    lift = Lift(capacity=1)
     a1 = Agent(1)
     lift.enqueue(a1)
     assert lift.state == "idle"
@@ -34,7 +35,7 @@ def test_state_transitions():
 
 
 def test_load_when_fewer_agents_than_capacity():
-    lift = Lift(capacity=3, cycle_time=5)
+    lift = Lift(capacity=3)
     a1 = Agent(1)
     lift.enqueue(a1)
 

--- a/zero_liftsim/lift.py
+++ b/zero_liftsim/lift.py
@@ -1,0 +1,76 @@
+"""Lift model for Zero Lift Simulator."""
+
+from __future__ import annotations
+
+from collections import deque
+from random import gauss
+
+from .agent import Agent
+
+
+class Lift:
+    """Single ski lift managing a FIFO queue and transport cycles."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self.queue: deque[Agent] = deque()
+        self.state: str = "idle"
+        self.current_riders: list[Agent] = []
+
+        self.ride_mean = 7
+        self.ride_sd = 1
+
+        self.traverse_mean = 5
+        self.traverse_sd = 1.5
+
+    def time_spent_ride_lift(self) -> float:
+        """Sample the time to ride the lift."""
+
+        return max(1, gauss(self.ride_mean, self.ride_sd))
+
+    def time_spent_traverse_down_mountain(self) -> float:
+        """Sample the time to ski down from the lift."""
+
+        return max(1, gauss(self.traverse_mean, self.traverse_sd))
+
+    # -- queue operations -------------------------------------------------
+    def enqueue(self, agent: Agent) -> None:
+        """Add ``agent`` to the end of the waiting queue."""
+
+        self.queue.append(agent)
+
+    def queue_length(self) -> int:
+        """Return the current number of waiting agents."""
+
+        return len(self.queue)
+
+    # -- loading ----------------------------------------------------------
+    def load(self) -> list[Agent]:
+        """Load agents from the queue up to ``capacity`` and set state.
+
+        Returns
+        -------
+        list[Agent]
+            Agents that boarded the lift.
+        """
+
+        if self.state != "idle":
+            return []
+
+        boarded: list[Agent] = []
+        while self.queue and len(boarded) < self.capacity:
+            agent = self.queue.popleft()
+            agent.boarded = True
+            boarded.append(agent)
+
+        if boarded:
+            self.state = "moving"
+            self.current_riders = list(boarded)
+
+        return boarded
+
+    def mark_idle(self) -> None:
+        """Mark the lift as idle after completing a cycle."""
+
+        self.state = "idle"
+        self.current_riders = []

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -8,12 +8,12 @@ from datetime import datetime, timedelta
 
 from zero_liftsim.main import (
     Simulation,
-    Lift,
     Agent,
     ArrivalEvent,
     BoardingEvent,
     ReturnEvent,
 )
+from zero_liftsim.lift import Lift
 from zero_liftsim.logging import Logger
 
 
@@ -30,8 +30,6 @@ class SimulationManager:
         Number of agents that will participate in the simulation.
     lift_capacity : int
         Number of agents a lift can board per cycle.
-    cycle_time : int
-        Minutes for the lift to complete one round trip.
     start_datetime : datetime, optional
         When the simulation begins. Defaults to 2025-03-12 09:00.
     logger : Logger, optional
@@ -53,13 +51,11 @@ class SimulationManager:
         *,
         n_agents: int,
         lift_capacity: int,
-        cycle_time: int,
         start_datetime: datetime | None = None,
         logger: Logger | None = None,
     ) -> None:
         self.n_agents = n_agents
         self.lift_capacity = lift_capacity
-        self.cycle_time = cycle_time
         self.start_datetime = start_datetime or datetime(2025, 3, 12, 9, 0, 0)
         self.logger = logger or Logger()
         self.sim: Simulation | None = None
@@ -69,7 +65,7 @@ class SimulationManager:
 
     def _setup(self) -> None:
         self.sim = Simulation()
-        self.lift = Lift(self.lift_capacity, self.cycle_time)
+        self.lift = Lift(self.lift_capacity)
         self.agents = [Agent(i + 1, logger=self.logger) for i in range(self.n_agents)]
         self.arrival_times = []
         for i, agent in enumerate(self.agents):


### PR DESCRIPTION
## Summary
- create `zero_liftsim.lift` with `Lift` class
- remove `Lift` from `main` and update imports
- drop `cycle_time` parameter and use `Lift.time_spent_ride_lift` when scheduling
- adjust `SimulationManager` and `run_alpha_sim`
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b46f243088323a501362f2a42d2fb