### PR TITLE
Implement continuous simulation runtime

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -9,17 +9,17 @@
 - [Initial Develop Description - Zero Lift Simulator](main_notes_implementation.md)
 
 ## Prompt Articles
-- [prompt0 - simulation class](prompt0_dev_init_class.md)
-- [prompt9 - Implement Multi-Lift Setup stimulating-divide 3437c905](prompt10_multi_lift_sim.md)
-- [prompt1 - lift class](prompt1_implement_lift.md)
-- [prompt2 - event classes](prompt2_event_classes.md)
-- [prompt3 - agent class](prompt3_agent_class.md)
-- [prompt4 - alpha simulation and logging](prompt4_implement_alpha_sim.md)
-- [prompt5 - full agent logging](prompt5_full_agent_logging.md)
-- [prompt6 - agent logging](prompt6_agent_logging.md)
-- [prompt7 - simulation datetime logging](prompt7_simulation_datetime.md)
+- [prompt9 - clock simulation runtime](prompt99_clock_simulation_runtime.md)
+- [prompt10 - Implement Multi-Lift Setup stimulating-divide 3437c905](prompt10_multi_lift_sim.md)
 - [prompt8 - Implement AgentExperience class](prompt8_time_distribution_enhancement.md)
-- [prompt99 - clock simulation runtime](prompt99_clock_simulation_runtime.md)
+- [prompt7 - simulation datetime logging](prompt7_simulation_datetime.md)
+- [prompt6 - agent logging](prompt6_agent_logging.md)
+- [prompt5 - full agent logging](prompt5_full_agent_logging.md)
+- [prompt4 - alpha simulation and logging](prompt4_implement_alpha_sim.md)
+- [prompt3 - agent class](prompt3_agent_class.md)
+- [prompt2 - event classes](prompt2_event_classes.md)
+- [prompt1 - lift class](prompt1_implement_lift.md)
+- [prompt0 - simulation class](prompt0_dev_init_class.md)
 
 ## Articles
 - [How to Add Wiki Articles](adding_wiki_articles.md)
@@ -50,5 +50,3 @@
 - [Updating Dependencies](updating_dependencies.md)
 - [Wiki Article Creation Instructions for Codex](wiki_article_creation_for_codex.md)
 - [Article Title](wiki_article_template.md)
-
-*** 

--- a/docs/simulation_manager_tutorial.md
+++ b/docs/simulation_manager_tutorial.md
@@ -3,7 +3,8 @@ random codename: animated-event e6b82433
 ***
 The `SimulationManager` class orchestrates configuration and execution
 of a lift simulation. Instantiate it with parameters similar to an
-`sklearn` estimator and call ``run`` to execute the simulation.
+`sklearn` estimator and call ``run`` to execute the simulation for a
+specified duration.
 
 ```python
 from zero_liftsim.simmanager import SimulationManager
@@ -11,9 +12,8 @@ from zero_liftsim.simmanager import SimulationManager
 manager = SimulationManager(
     n_agents=3,
     lift_capacity=2,
-    cycle_time=5,
 )
-result = manager.run()
+result = manager.run(runtime_minutes=60)
 print(result)
 ```
 

--- a/tests/test_alpha_sim.py
+++ b/tests/test_alpha_sim.py
@@ -23,7 +23,10 @@ def test_run_alpha_sim_metrics():
     orig = Lift.time_spent_ride_lift
     Lift.time_spent_ride_lift = lambda self: 5
     result = run_alpha_sim(
-        n_agents=3, lift_capacity=2, start_datetime=start
+        n_agents=3,
+        lift_capacity=2,
+        start_datetime=start,
+        runtime_minutes=10,
     )
     Lift.time_spent_ride_lift = orig
     assert result["total_rides"] == 3

--- a/tests/test_docs_tools.py
+++ b/tests/test_docs_tools.py
@@ -5,6 +5,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from zero_liftsim.docs_tools import new_doc
 from zero_liftsim.cli import build_parser
+from zero_liftsim import dev
 
 
 def test_cli_parses_new_doc():
@@ -21,3 +22,11 @@ def test_new_doc_creates_file(tmp_path):
     text = path.read_text()
     assert text.startswith("# unnamed")
     assert "random codename:" in text
+
+
+def test_generate_docs_toc_includes_all_prompts():
+    toc = dev.generate_docs_toc()
+    prompt_lines = [l for l in toc.splitlines() if l.startswith("- [prompt")]
+    # ensure prompt99 appears first when sorted descending
+    assert prompt_lines[0].startswith("- [prompt9")
+    assert len(prompt_lines) >= 10

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.simmanager import SimulationManager
+
+from zero_liftsim.lift import Lift
+
+
+def test_simulation_runs_until_stop_time():
+    start = datetime(2025, 3, 12, 9, 0, 0)
+    manager = SimulationManager(n_agents=1, lift_capacity=1, start_datetime=start)
+    manager._setup()
+    manager.lift.time_spent_ride_lift = lambda: 5
+    manager.lift.time_spent_traverse_down_mountain = lambda: 5
+    result = manager.run(runtime_minutes=420)
+    agent = manager.agents[0]
+    assert agent.rides_completed > 1
+    assert manager.sim.current_time <= 420
+    assert result["total_rides"] == agent.rides_completed

--- a/zero_liftsim/dev.py
+++ b/zero_liftsim/dev.py
@@ -24,19 +24,19 @@ def generate_docs_toc() -> str:
     """Generate a Markdown table of contents for Markdown files in ``docs``."""
     docs_dir = Path(__file__).resolve().parent.parent / "docs"
     main_paths: list[Path] = sorted(docs_dir.glob("main_notes*md"))
-    prompt_paths: list[Path] = []
+    prompt_paths = list(docs_dir.glob("prompt*md"))
+    prompt_paths.sort(
+        key=lambda p: int(p.stem.split("_", 1)[0].replace("prompt", "")),
+        reverse=True,
+    )
     other_paths: list[Path] = []
 
+    used = set(main_paths) | set(prompt_paths)
     for path in sorted(docs_dir.glob("*.md")):
         name = path.name.lower()
-        if name in {"readme.md", "contents.md"}:
+        if name in {"readme.md", "contents.md"} or path in used:
             continue
-        if path in main_paths:
-            continue
-        if path.stem.lower().startswith("prompt"):
-            prompt_paths.append(path)
-        else:
-            other_paths.append(path)
+        other_paths.append(path)
 
     lines = []
     lines.append("## Main Notes")


### PR DESCRIPTION
## Summary
- extend `SimulationManager.run` to support runtime window and update metrics
- store stop time in Simulation and reschedule arrivals until end time
- add `runtime_minutes` option to `run_alpha_sim`
- update docs to document runtime option and rebuild table of contents
- ensure docs TOC lists prompt articles in descending order
- add unit tests for new runtime behavior and TOC generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b5282f474832392908682e60c8064