### PR TITLE
Fix prompt sorting in docs TOC

### DIFF
--- a/tests/test_docs_tools.py
+++ b/tests/test_docs_tools.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import re
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -27,6 +28,10 @@ def test_new_doc_creates_file(tmp_path):
 def test_generate_docs_toc_includes_all_prompts():
     toc = dev.generate_docs_toc()
     prompt_lines = [l for l in toc.splitlines() if l.startswith("- [prompt")]
-    # ensure prompt99 appears first when sorted descending
-    assert prompt_lines[0].startswith("- [prompt9")
+    numbers = []
+    for line in prompt_lines:
+        link = line.split("(")[1].split(")")[0]
+        num = int(re.search(r"prompt[_-]?(\d+)", link).group(1))
+        numbers.append(num)
+    assert numbers == sorted(numbers, reverse=True)
     assert len(prompt_lines) >= 10

--- a/zero_liftsim/dev.py
+++ b/zero_liftsim/dev.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Developer utilities for zero-liftsim."""
 
 from pathlib import Path
+import re
 
 
 
@@ -20,15 +21,23 @@ def _title_from_filename(name: str) -> str:
     return base.title()
 
 
+_PROMPT_RE = re.compile(r"^prompt[_-]?(\d+)")
+
+
+def _prompt_number(path: Path) -> int:
+    """Return the integer prompt index extracted from ``path``."""
+    match = _PROMPT_RE.match(path.stem)
+    if match:
+        return int(match.group(1))
+    return -1
+
+
 def generate_docs_toc() -> str:
     """Generate a Markdown table of contents for Markdown files in ``docs``."""
     docs_dir = Path(__file__).resolve().parent.parent / "docs"
     main_paths: list[Path] = sorted(docs_dir.glob("main_notes*md"))
     prompt_paths = list(docs_dir.glob("prompt*md"))
-    prompt_paths.sort(
-        key=lambda p: int(p.stem.split("_", 1)[0].replace("prompt", "")),
-        reverse=True,
-    )
+    prompt_paths.sort(key=_prompt_number, reverse=True)
     other_paths: list[Path] = []
 
     used = set(main_paths) | set(prompt_paths)


### PR DESCRIPTION
## Summary
- ensure prompt docs are sorted numerically descending
- add tests for descending order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b5dffa3688323ac81dffbe02aba8f