### PR TITLE
Add helper for loading templates

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.helpers import load_asset_template
+
+
+def test_load_asset_template_returns_template():
+    tmpl = load_asset_template("new_doc_template.md.j2")
+    if hasattr(tmpl, "render"):
+        text = tmpl.render(codename="example")
+    else:
+        text = tmpl.replace("{{ codename }}", "example")
+    assert "example" in text

--- a/zero_liftsim/docs_tools.py
+++ b/zero_liftsim/docs_tools.py
@@ -4,27 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .helpers import codename
-
-try:
-    from jinja2 import Environment, FileSystemLoader
-except ModuleNotFoundError:  # pragma: no cover - fallback if jinja2 missing
-    Environment = None
-    FileSystemLoader = None
+from .helpers import codename, load_asset_template
 
 
 _TEMPLATE_NAME = "new_doc_template.md.j2"
 
 
 def _load_template() -> str:
-    assets = Path(__file__).resolve().parent / "assets"
-    if Environment is None:
-        # fallback simple template
-        path = assets / _TEMPLATE_NAME
-        return path.read_text(encoding="utf-8")
-    env = Environment(loader=FileSystemLoader(str(assets)))
-    template = env.get_template(_TEMPLATE_NAME)
-    return template
+    return load_asset_template(_TEMPLATE_NAME)
 
 
 def new_doc(*, docs_dir: Path | None = None) -> Path:

--- a/zero_liftsim/helpers.py
+++ b/zero_liftsim/helpers.py
@@ -6,10 +6,37 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for environments with
         """Simplistic fallback that returns the first eight characters."""
         return value[:8]
 from uuid import uuid4 as uuid
+from pathlib import Path
+
+try:
+    from jinja2 import Environment, FileSystemLoader
+except ModuleNotFoundError:  # pragma: no cover - fallback if jinja2 missing
+    Environment = None
+    FileSystemLoader = None
 
 
 def codename():
     """Generate random codename"""
     i = str(uuid())
     return {'uuid':i, 'name':cd(i)}
+
+
+def load_asset_template(name: str):
+    """Load a jinja2 template bundled in ``assets``.
+
+    Parameters
+    ----------
+    name:
+        File name of the template to load.
+    """
+
+    assets = Path(__file__).resolve().parent / "assets"
+    if Environment is None:
+        # jinja2 missing, fall back to plain text
+        path = assets / name
+        return path.read_text(encoding="utf-8")
+
+    env = Environment(loader=FileSystemLoader(str(assets)))
+    template = env.get_template(name)
+    return template
 


### PR DESCRIPTION
## Summary
- add `load_asset_template` helper for loading templates from project assets
- use the helper in documentation utilities
- test the template loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6dee06548323aa253b6787785c45