### PR TITLE
Rewrite visualize module

### DIFF
--- a/zero_liftsim/visualize.py
+++ b/zero_liftsim/visualize.py
@@ -1,70 +1,98 @@
+"""Visualization utilities for agent state snapshots."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
 import matplotlib.pyplot as plt
 import pandas as pd
-from datetime import datetime
 
 
-def visualize_states(agent_exp_log_data, time: datetime, out_path="state_diagram.png") -> None:
-    """Visualize agent states as blocks on a state machine diagram.
+def visualize_states(
+    agent_exp_log_data: pd.DataFrame | Mapping[str, pd.DataFrame],
+    time: datetime,
+    out_path: str = "state_diagram.png",
+) -> None:
+    """Render a simple state diagram showing agent positions.
 
     Parameters
     ----------
-    agent_exp_log_data:
-        Either a dictionary containing a DataFrame under the ``"agent_log"`` key
-        or a DataFrame itself.
-    time:
+    agent_exp_log_data : pandas.DataFrame or Mapping[str, pandas.DataFrame]
+        Data containing an ``"agent_log"`` table. If a mapping is supplied it
+        must provide this key. The table must include ``"event"``,
+        ``"agent_uuid`` and ``"time`` columns. Older logs may instead use a
+        ``"description"`` column in place of ``"event``, which will be handled
+        automatically.
+    time : datetime
         Point in time to visualize.
-    out_path:
-        File path for the output PNG.
+    out_path : str, optional
+        File path where the PNG diagram will be written.
     """
-    # Fixed layout for states
-    state_positions = {
-        "start_wait": (0, 0),
-        "board": (1, 1),
-        "ride": (2, 0),
-        "exit": (3, 1),
-        "return": (4, 0),
-    }
-
-    fig, ax = plt.subplots(figsize=(10, 4))
-    ax.set_xlim(-1, 5)
-    ax.set_ylim(-1, 2)
-    ax.axis('off')
-
-    # Draw state nodes
-    for state, (x, y) in state_positions.items():
-        ax.add_patch(plt.Circle((x, y), 0.2, color='gray', zorder=1))
-        ax.text(x, y + 0.3, state, ha='center', fontsize=10)
 
     if isinstance(agent_exp_log_data, pd.DataFrame):
         df = agent_exp_log_data
     else:
         try:
             df = agent_exp_log_data["agent_log"]
-        except (TypeError, KeyError) as exc:
+        except Exception as exc:  # pragma: no cover - type/KeyError
             raise ValueError(
-                "agent_exp_log_data must be a DataFrame or a dict containing 'agent_log'"
+                "agent_exp_log_data must be a DataFrame or mapping containing 'agent_log'"
             ) from exc
 
-    df = df.sort_values("time")  # Ensure time ordering
+    required_cols = {"event", "agent_uuid", "time"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        # Some older logs used 'description' instead of 'event'. Handle that
+        # transparently so visualization still works.
+        if "event" not in df.columns and "description" in df.columns:
+            df = df.rename(columns={"description": "event"})
+            missing = required_cols - set(df.columns)
 
-    # Latest event per agent before or at the given time
-    latest_states = (
-        df[df["time"] <= time]
-        .groupby("agent_uuid")
-        .tail(1)
-    )
+    if missing:
+        raise ValueError(
+            "agent_log missing columns: "
+            + ", ".join(sorted(missing))
+            + ". Did you pass SimulationManager.retrieve_data()['agent_log']?"
+        )
 
-    # Draw agent boxes
-    for _, row in latest_states.iterrows():
+    df = df.sort_values("time")
+    latest = df[df["time"] <= time].groupby("agent_uuid").tail(1)
+
+    state_positions = {
+        "start_wait": (0, 0),
+        "arrival": (1, 0.5),
+        "board": (2, 0),
+        "ride_complete": (3, 0.5),
+    }
+
+    fig, ax = plt.subplots(figsize=(8, 3))
+    ax.set_xlim(-0.5, 3.5)
+    ax.set_ylim(-0.5, 1.5)
+    ax.axis("off")
+
+    for state, (x, y) in state_positions.items():
+        ax.add_patch(plt.Circle((x, y), 0.15, color="gray", zorder=1))
+        ax.text(x, y + 0.25, state, ha="center", fontsize=9)
+
+    for _, row in latest.iterrows():
         event = row["event"]
         agent_uuid = row["agent_uuid"]
         if event in state_positions:
             x, y = state_positions[event]
-            ax.add_patch(plt.Rectangle((x - 0.05, y - 0.05), 0.1, 0.1, color='blue', zorder=2))
-            ax.text(x, y, str(agent_uuid), ha='center', va='center', color='white', fontsize=6, zorder=3)
+            ax.add_patch(
+                plt.Rectangle((x - 0.05, y - 0.05), 0.1, 0.1, color="blue", zorder=2)
+            )
+            ax.text(
+                x,
+                y,
+                str(agent_uuid)[:4],
+                ha="center",
+                va="center",
+                color="white",
+                fontsize=6,
+                zorder=3,
+            )
 
-    plt.savefig(out_path, dpi=150)
-    plt.close()
-
-"ready to use – just feed it `agent_exp_log_data` and a datetime to generate frame PNGs."
-
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- refresh `visualize.py` with a working implementation
- add better error handling for missing event columns

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b78de3bb8832384fc97286c130b58