### PR TITLE
Implement multi-chair lift logic

### DIFF
--- a/docs/alpha_sim_usage.md
+++ b/docs/alpha_sim_usage.md
@@ -6,7 +6,7 @@ Use `run_alpha_sim` to execute a short run and gather basic metrics.
 ```python
 from zero_liftsim.main import run_alpha_sim
 
-summary = run_alpha_sim(n_agents=3, lift_capacity=2, cycle_time=5)
+summary = run_alpha_sim(n_agents=3, lift_capacity=2)
 print(summary)
 ```
 
@@ -25,12 +25,15 @@ from zero_liftsim.main import Simulation, Lift, Agent, ArrivalEvent
 
 logger = Logger()
 sim = Simulation()
-lift = Lift(capacity=1, cycle_time=5)
+lift = Lift(capacity=1, num_chairs=1)
 agent = Agent(1)
 sim.schedule(ArrivalEvent(agent, lift), 0)
 sim.run(logger=logger)
 print(logger.records())
 ```
+
+The ``num_chairs`` parameter controls how many lift chairs circulate
+simultaneously. Loading occurs only when a chair is available.
 
 Each logged entry is also appended to ``logs/main.log`` by default.
 You can supply a different filename to ``Logger`` and it will be
@@ -59,5 +62,5 @@ The file ``logs/debug.log`` will contain a line similar to::
 2025-06-19T12:00:00 initializing setup
 ```
 # Git Info
-Commit: 2123fb0b47c5df266f76bdbf8a0f945c1fcc72b6
-Date: 2025-06-11T18:41:52-07:00
+Commit: 61e0c90086234dee06b15b744dc31f212592a15f
+Date: 2025-06-13T00:35:24+00:00

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -43,3 +43,26 @@ def test_load_when_fewer_agents_than_capacity():
     assert boarded == [a1]
     assert lift.queue_length() == 0
     assert lift.state == "moving"
+
+
+def test_multiple_chairs_limit_loading_and_return():
+    lift = Lift(capacity=1, num_chairs=2)
+    a1, a2, a3 = Agent(1), Agent(2), Agent(3)
+    for a in (a1, a2, a3):
+        lift.enqueue(a)
+
+    first = lift.load()
+    second = lift.load()
+    third = lift.load()
+
+    assert len(first) == 1
+    assert len(second) == 1
+    assert third == []
+    assert lift.available_chairs() == 0
+    assert lift.riders_in_transit() == 2
+
+    lift.chair_return(first)
+    assert lift.available_chairs() == 1
+
+    boarded = lift.load()
+    assert boarded == [a3]

--- a/zero_liftsim/lift.py
+++ b/zero_liftsim/lift.py
@@ -11,11 +11,24 @@ from .agent import Agent
 class Lift:
     """Single ski lift managing a FIFO queue and transport cycles."""
 
-    def __init__(self, capacity: int) -> None:
+    def __init__(self, capacity: int, num_chairs: int = 1) -> None:
+        """Initialize lift parameters.
+
+        Parameters
+        ----------
+        capacity:
+            Number of riders each chair can hold.
+        num_chairs:
+            Total number of chairs circulating on the lift.
+        """
+
         self.capacity = capacity
+        self.num_chairs = num_chairs
         self.queue: deque[Agent] = deque()
         self.state: str = "idle"
-        self.current_riders: list[Agent] = []
+        self.current_riders: list[list[Agent]] = []
+        self.chairs_available = num_chairs
+        self.chairs_in_transit = 0
 
         self.ride_mean = 7
         self.ride_sd = 1
@@ -54,7 +67,7 @@ class Lift:
             Agents that boarded the lift.
         """
 
-        if self.state != "idle":
+        if self.chairs_available == 0:
             return []
 
         boarded: list[Agent] = []
@@ -65,12 +78,42 @@ class Lift:
 
         if boarded:
             self.state = "moving"
-            self.current_riders = list(boarded)
+            self.current_riders.append(list(boarded))
+            self.chairs_available -= 1
+            self.chairs_in_transit += 1
 
         return boarded
 
     def mark_idle(self) -> None:
-        """Mark the lift as idle after completing a cycle."""
+        """Mark the lift completely idle, resetting all chairs."""
 
         self.state = "idle"
         self.current_riders = []
+        self.chairs_available = self.num_chairs
+        self.chairs_in_transit = 0
+
+    def chair_return(self, riders: list[Agent]) -> None:
+        """Mark a single chair as returned to the base."""
+
+        if riders in self.current_riders:
+            self.current_riders.remove(riders)
+        self.chairs_available += 1
+        self.chairs_in_transit = max(self.chairs_in_transit - 1, 0)
+        if self.chairs_in_transit == 0:
+            self.state = "idle"
+
+    # -- chair info ------------------------------------------------------
+    def available_chairs(self) -> int:
+        """Return the number of chairs currently at the base."""
+
+        return self.chairs_available
+
+    def total_chairs(self) -> int:
+        """Return the total number of chairs on the lift."""
+
+        return self.num_chairs
+
+    def riders_in_transit(self) -> int:
+        """Return the number of riders currently on the lift."""
+
+        return sum(len(r) for r in self.current_riders)


### PR DESCRIPTION
## Summary
- extend `Lift` with `num_chairs` and chair tracking helpers
- update event classes to manage several chairs at once
- document how to use `num_chairs`
- add regression test for multiple chairs

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b79b13e388323936803d0db0d3d4e