### PR TITLE
Implement visualization function and lazy pandas import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "codenamize",
     "pytest",
     "pandas",
+    "matplotlib",
 ]
 
 [project.scripts]

--- a/zero_liftsim/__init__.py
+++ b/zero_liftsim/__init__.py
@@ -1,6 +1,7 @@
 """Top level package for zero_liftsim."""
 
-__all__ = ["__version__", "main"]
+__all__ = ["__version__", "main", "state_viz"]
 __version__ = "0.1.0"
 
 from . import main
+from . import state_viz

--- a/zero_liftsim/main.py
+++ b/zero_liftsim/main.py
@@ -244,7 +244,7 @@ class ArrivalEvent(Event):
             lift_state=self.lift.state,
         )
         events: list[tuple[Event, int]] = []
-        if self.lift.available_chairs() > 0:
+        if self.lift.state == "idle" and self.lift.available_chairs() > 0:
             events.append((BoardingEvent(self.lift), simulation.current_time))
         return events
 # }}}

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-import pandas as pd
 from datetime import datetime, timedelta
 
 from zero_liftsim.main import (
@@ -135,6 +134,7 @@ class SimulationManager:
 
     def retrieve_data(self):
         """Retrieve key dataframes that summarize simulation"""
+        import pandas as pd
         data = {}
         for k in ['exp_rideloop', 'agent_log']:
             data[k] = pd.DataFrame()

--- a/zero_liftsim/state_viz.py
+++ b/zero_liftsim/state_viz.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import matplotlib.pyplot as plt
+except ModuleNotFoundError:  # pragma: no cover - fallback if matplotlib missing
+    plt = None
+
+
+def visualize_states(
+    agent_exp_log_data: dict,
+    time: datetime,
+    out_path: str = "state_diagram.png",
+) -> None:
+    """Generate a static visualization of agent states.
+
+    Parameters
+    ----------
+    agent_exp_log_data : dict
+        Dictionary containing ``agent_log`` and ``exp_rideloop`` data frames.
+    time : datetime
+        Timestamp to snapshot.
+    out_path : str, optional
+        File path for the PNG output.
+    """
+
+    if plt is None:  # pragma: no cover - avoid failure if matplotlib is absent
+        raise RuntimeError("matplotlib is required for visualize_states")
+
+    import pandas as pd
+
+    state_positions = {
+        "start_wait": (0, 0),
+        "board": (1, 1),
+        "ride": (2, 0),
+        "exit": (3, 1),
+        "return": (4, 0),
+    }
+
+    agent_log: pd.DataFrame = agent_exp_log_data.get("agent_log", pd.DataFrame())
+    if agent_log.empty:
+        return
+    agent_log = agent_log[agent_log["time"] <= time]
+    if agent_log.empty:
+        return
+    agent_log = agent_log.sort_values("time").groupby("agent_id").tail(1)
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    ax.axis("off")
+
+    for name, (x, y) in state_positions.items():
+        circle = plt.Circle((x, y), 0.2, facecolor="lightgray", edgecolor="black")
+        ax.add_patch(circle)
+        ax.text(x, y + 0.3, name, ha="center", va="bottom", fontsize=8)
+
+    for _, row in agent_log.iterrows():
+        event = row.get("event")
+        if event not in state_positions:
+            continue
+        x, y = state_positions[event]
+        rect = plt.Rectangle(
+            (x - 0.15, y - 0.15),
+            0.3,
+            0.3,
+            facecolor="white",
+            edgecolor="black",
+        )
+        ax.add_patch(rect)
+        ax.text(x, y, str(row.get("agent_id")), ha="center", va="center", fontsize=6)
+
+    ax.set_xlim(-0.5, 4.5)
+    ax.set_ylim(-0.5, 1.5)
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    plt.tight_layout()
+    plt.savefig(out_path, dpi=200)
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- implement `visualize_states` for state diagrams
- add matplotlib dependency
- expose new module in package init
- lazily import pandas in `SimulationManager`
- prevent boarding while lift is moving

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b80556a84832392b6e4f0a7364484