### PR TITLE
Implement pandas accessor for time indexing

### DIFF
--- a/tests/test_pandas_ext.py
+++ b/tests/test_pandas_ext.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim import pandas_ext  # noqa: F401
+
+
+def test_get_nearest_time_index():
+    df = pd.DataFrame({
+        'time': pd.date_range('2025-01-01', periods=3, freq='H'),
+        'value': [1, 2, 3]
+    })
+    idx = df.zero.get_nearest_time_index(pd.Timestamp('2025-01-01T01:20:00'))
+    assert idx == 1
+
+
+def test_missing_or_multiple_time_columns():
+    df_missing = pd.DataFrame({'value': [1, 2, 3]})
+    with pytest.raises(ValueError):
+        df_missing.zero.get_nearest_time_index(pd.Timestamp('2025-01-01'))
+
+    df_multi = pd.DataFrame({
+        'time': pd.date_range('2025-01-01', periods=3, freq='H'),
+        'timestamp': pd.date_range('2025-01-01', periods=3, freq='H'),
+    })
+    with pytest.raises(ValueError):
+        df_multi.zero.get_nearest_time_index(pd.Timestamp('2025-01-01'))

--- a/zero_liftsim/__init__.py
+++ b/zero_liftsim/__init__.py
@@ -5,3 +5,4 @@ __version__ = "0.1.0"
 
 from . import main
 from . import state_viz
+from . import pandas_ext  # noqa: F401 -- register pandas accessor

--- a/zero_liftsim/pandas_ext.py
+++ b/zero_liftsim/pandas_ext.py
@@ -1,0 +1,37 @@
+"""Pandas DataFrame extensions for zero_liftsim."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
+
+
+@pd.api.extensions.register_dataframe_accessor("zero")
+class ZeroAccessor:
+    """Provide Zero Lift helper methods for :class:`pandas.DataFrame`."""
+
+    _TIME_COLS: List[str] = ["time", "timestamp", "date"]
+
+    def __init__(self, pandas_obj: pd.DataFrame) -> None:
+        self._obj = pandas_obj
+
+    def _find_time_column(self) -> str:
+        candidates = [c for c in self._TIME_COLS if c in self._obj.columns]
+        if len(candidates) != 1:
+            raise ValueError(
+                "DataFrame must contain exactly one time column among "
+                f"{self._TIME_COLS}."
+            )
+        col = candidates[0]
+        if not is_datetime64_any_dtype(self._obj[col]):
+            raise ValueError(f"Column '{col}' is not datetime-like")
+        return col
+
+    def get_nearest_time_index(self, index_time: pd.Timestamp) -> int:
+        """Return index of row whose time is closest to ``index_time``."""
+
+        col = self._find_time_column()
+        diffs = (self._obj[col] - pd.Timestamp(index_time)).abs()
+        return diffs.idxmin()


### PR DESCRIPTION
## Summary
- add a `zero` pandas DataFrame accessor with `get_nearest_time_index`
- register accessor on import
- test behaviour for nearest index and error cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684bfd41d9d883238a9114bf9c4b86c2