### PR TITLE
Clarify agent state inference

### DIFF
--- a/zero_liftsim/sandbox.py
+++ b/zero_liftsim/sandbox.py
@@ -12,6 +12,14 @@ state_riding_lift = "state_riding_lift"
 state_in_queue = "state_in_queue"
 state_traversing_down = "state_traversing_down"
 
+# Explicit mapping from activity log events to the above states
+_EVENT_STATE_MAP = {
+    "board": state_riding_lift,
+    "ride_complete": state_traversing_down,
+    "start_wait": state_in_queue,
+    "arrival": state_in_queue,
+}
+
 def infer_agent_states(agents: Iterable[Agent], dt: datetime) -> Dict[str, str]:
     """Categorize agents based on their activity log at ``dt``.
 
@@ -36,11 +44,11 @@ def infer_agent_states(agents: Iterable[Agent], dt: datetime) -> Dict[str, str]:
             if t <= dt and (latest_time is None or t > latest_time):
                 latest_time = t
                 latest_event = entry.get("event")
-        if latest_event == "board":
-            state = state_riding_lift
-        elif latest_event == "ride_complete":
-            state = state_traversing_down
-        else:
+
+        if latest_event is None:
+            # if no event has occurred yet, the agent is still waiting in queue
             state = state_in_queue
+        else:
+            state = _EVENT_STATE_MAP.get(latest_event, state_in_queue)
         results[agent.agent_uuid] = state
     return results


### PR DESCRIPTION
## Summary
- map activity log events to explicit agent states
- use the mapping when inferring agent state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c17a095188323be63fc883f54462b