### PR TITLE
Add UnknownEventError for sandbox

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -84,6 +84,5 @@ def test_get_latest_event_unrecognized_event():
     agent = Agent(7)
     ts = datetime(2025, 3, 12, 9, 0, 0)
     agent.activity_log[0] = {"time": ts.isoformat(), "event": "foo"}
-    with pytest.raises(KeyError):
-        agent.get_latest_event(ts)
+    assert agent.get_latest_event(ts) == "foo"
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,7 +5,13 @@ from datetime import datetime, timedelta
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from zero_liftsim.agent import Agent
-from zero_liftsim.sandbox import infer_agent_states, state_riding_lift, state_in_queue, state_traversing_down
+from zero_liftsim.sandbox import (
+    infer_agent_states,
+    state_riding_lift,
+    state_in_queue,
+    state_traversing_down,
+    UnknownEventError,
+)
 import pytest
 
 
@@ -35,5 +41,5 @@ def test_infer_agent_states_unknown_event():
     agent = Agent(2)
     start = datetime(2025, 3, 12, 9, 0, 0)
     agent.log_event("foo", 0, start.isoformat())
-    with pytest.raises(KeyError):
+    with pytest.raises(UnknownEventError):
         infer_agent_states([agent], start)

--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -121,13 +121,9 @@ class Agent:
         ------
         ValueError
             If no event occurred at or before ``dt``.
-        KeyError
-            If the resulting event is not recognized by :data:`_EVENT_STATE_MAP`.
         """
 
         from datetime import datetime as _dt
-        # lazy import to avoid circular dependency
-        from .sandbox import _EVENT_STATE_MAP
 
         latest_event = None
         latest_time = None
@@ -139,8 +135,6 @@ class Agent:
 
         if latest_event is None:
             raise ValueError("no event before provided datetime")
-        if latest_event not in _EVENT_STATE_MAP:
-            raise KeyError(latest_event)
 
         return latest_event
 

--- a/zero_liftsim/sandbox.py
+++ b/zero_liftsim/sandbox.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Iterable, Dict
 
+
+class UnknownEventError(Exception):
+    """Raised when :func:`infer_agent_states` encounters an unknown event."""
+
 from .agent import Agent
 
 # State constants used when categorizing agents
@@ -40,6 +44,8 @@ def infer_agent_states(agents: Iterable[Agent], dt: datetime) -> Dict[str, str]:
     results: Dict[str, str] = {}
     for agent in agents:
         latest_event = agent.get_latest_event(dt)
+        if latest_event not in _EVENT_STATE_MAP:
+            raise UnknownEventError(latest_event)
         results[agent.agent_uuid] = _EVENT_STATE_MAP[latest_event]
 
     return results


### PR DESCRIPTION
## Summary
- relax Agent.get_latest_event validation and just return latest log entry
- raise `UnknownEventError` from `infer_agent_states` when an event isn't in the mapping
- update agent and sandbox tests for the new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c26df265c832383fe4dc0c445cf43