### PR TITLE
Add configuration helper functions

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from zero_liftsim.helpers import load_asset_template
+from zero_liftsim.helpers import load_asset_template, base_config, update_params
 
 
 def test_load_asset_template_returns_template():
@@ -13,3 +13,14 @@ def test_load_asset_template_returns_template():
     else:
         text = tmpl.replace("{{ codename }}", "example")
     assert "example" in text
+
+
+def test_base_config_contains_commit():
+    cfg = base_config()
+    assert "git_commit" in cfg
+    assert len(cfg["git_commit"]) >= 7
+
+
+def test_update_params_overrides_nested_values():
+    cfg = update_params(Lift={"ride_sd": 2})
+    assert cfg["Lift"]["ride_sd"] == 2


### PR DESCRIPTION
## Summary
- add configuration helpers `base_config` and `update_params`
- add tests for the new helpers

## Testing
- `python -m pip install pandas` *(fails: Tunnel connection failed)*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c2c5fa46c8323a384bf7bb63b3f40