### PR TITLE
Support config-based SimulationManager

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -46,6 +46,7 @@
 - [codex: Update the Table of Contents](for_codex_update_toc.md)
 - [Git Tools](git-tools.md)
 - [Investigating Wait Time with Many Chairs](high_wait_analysis.md)
+- [Launching a Simulation](launching_a_simulation.md)
 - [Simulation Modeling Book Notes](law_simulation_book.md)
 - [Tutorial - Infer Agent State](partial-kernel-tutorial-infer-agent-states.md)
 - [Project Questions stingy-orange - answered](project_questions_orange.md)

--- a/docs/launching_a_simulation.md
+++ b/docs/launching_a_simulation.md
@@ -1,0 +1,23 @@
+# Launching a Simulation
+random codename: outgoing-way cd797da0
+***
+This tutorial demonstrates how to start a lift simulation using
+`SimulationManager` and the configuration dictionary returned by
+`base_config`.
+
+```python
+from zero_liftsim.helpers import base_config
+from zero_liftsim.simmanager import SimulationManager
+
+cfg = base_config()
+cfg["SimulationManager"]["__init__"].update({
+    "n_agents": 5,
+    "lift_capacity": 2,
+})
+manager = SimulationManager(cfg)
+summary = manager.run(runtime_minutes=60)
+print(summary)
+```
+
+The example sets up a simple one hour run with five agents and a
+two-person lift. `summary` contains the total rides and average wait time.

--- a/docs/simulation_manager_tutorial.md
+++ b/docs/simulation_manager_tutorial.md
@@ -2,17 +2,16 @@
 random codename: animated-event e6b82433
 ***
 The `SimulationManager` class orchestrates configuration and execution
-of a lift simulation. Instantiate it with parameters similar to an
-`sklearn` estimator and call ``run`` to execute the simulation for a
-specified duration.
+of a lift simulation. Instantiate it with a configuration dictionary and
+call ``run`` to execute the simulation for a specified duration.
 
 ```python
 from zero_liftsim.simmanager import SimulationManager
+from zero_liftsim.helpers import base_config
 
-manager = SimulationManager(
-    n_agents=3,
-    lift_capacity=2,
-)
+cfg = base_config()
+cfg["SimulationManager"]["__init__"].update({"n_agents": 3, "lift_capacity": 2})
+manager = SimulationManager(cfg)
 result = manager.run(runtime_minutes=60)
 print(result)
 ```

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,13 +5,18 @@ from datetime import datetime
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from zero_liftsim.simmanager import SimulationManager
+from zero_liftsim.helpers import base_config
 
 from zero_liftsim.lift import Lift
 
 
 def test_simulation_runs_until_stop_time():
     start = datetime(2025, 3, 12, 9, 0, 0)
-    manager = SimulationManager(n_agents=1, lift_capacity=1, start_datetime=start)
+    cfg = base_config()
+    cfg["SimulationManager"]["__init__"].update(
+        {"n_agents": 1, "lift_capacity": 1, "start_datetime": start}
+    )
+    manager = SimulationManager(cfg)
     manager._setup()
     manager.lift.time_spent_ride_lift = lambda: 5
     manager.lift.time_spent_traverse_down_mountain = lambda: 5

--- a/zero_liftsim/helpers.py
+++ b/zero_liftsim/helpers.py
@@ -79,7 +79,12 @@ def base_config(**overrides: Any) -> Dict[str, Any]:
     cfg: Dict[str, Any] = {
         "git_commit": git_tools.HEAD_COMMIT,
         "SimulationManager": {
-            "__init__": _defaults_from_callable(SimulationManager.__init__),
+            "__init__": {
+                "n_agents": 1,
+                "lift_capacity": 1,
+                "start_datetime": None,
+                "logger": None,
+            },
             "run": _defaults_from_callable(SimulationManager.run),
         },
         "Simulation": {

--- a/zero_liftsim/simulation.py
+++ b/zero_liftsim/simulation.py
@@ -92,9 +92,15 @@ def run_alpha_sim(
     """Run a small simulation and return metrics."""
     from zero_liftsim.simmanager import SimulationManager
 
-    manager = SimulationManager(
-        n_agents=n_agents,
-        lift_capacity=lift_capacity,
-        start_datetime=start_datetime,
+    from zero_liftsim.helpers import base_config
+
+    cfg = base_config()
+    cfg["SimulationManager"]["__init__"].update(
+        {
+            "n_agents": n_agents,
+            "lift_capacity": lift_capacity,
+            "start_datetime": start_datetime,
+        }
     )
+    manager = SimulationManager(cfg)
     return manager.run(runtime_minutes=runtime_minutes)


### PR DESCRIPTION
## Summary
- add config-centric initialization for `SimulationManager`
- include defaults for `SimulationManager` in `base_config`
- update `run_alpha_sim` and runtime test
- document running the manager via config
- add tutorial on launching a simulation
- refresh docs table of contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c494ba6d88323916ea3e3eb533c79