### PR TITLE
Update TOC generation to use tags

### DIFF
--- a/docs/main_notes_adding_wiki_articles.md
+++ b/docs/main_notes_adding_wiki_articles.md
@@ -1,5 +1,6 @@
 # How to Add Wiki Articles
 
+#process-notes
 To contribute new articles to this wiki:
 
 1. Create a Markdown file in the `docs` directory. Use a short, descriptive file name with dashes or underscores.
@@ -10,4 +11,3 @@ To contribute new articles to this wiki:
 Commit: 1b3bf669fde173b2c5f630523fef8c84d36843d2
 Date: 2025-06-10T16:18:30-07:00
 
-#process-notes

--- a/docs/main_notes_as_a_human_how_to_code_with_codex.md
+++ b/docs/main_notes_as_a_human_how_to_code_with_codex.md
@@ -1,5 +1,6 @@
 # As a Human: How to Code with Codex
 
+#process-notes
 random codename: afraid-award b7af63fb
 
 ***
@@ -43,4 +44,3 @@ Writing prompts in the repo keeps a persistent record of what Codex was asked to
 Commit: 43db73f7df84193785b045c7924387d0090ba6e5
 Date: 2025-06-12T10:20:31-07:00
 
-#process-notes

--- a/docs/main_notes_best_practices_coding_with_codex.md
+++ b/docs/main_notes_best_practices_coding_with_codex.md
@@ -1,5 +1,6 @@
 # Best Practices for Coding with Codex
 
+#process-notes
 Follow these guidelines when working with Codex or other LLM-based tools:
 
 1. **Understand the context.** Read existing docs and comments to ensure new code fits the project.
@@ -11,4 +12,3 @@ Follow these guidelines when working with Codex or other LLM-based tools:
 Commit: 1b3bf669fde173b2c5f630523fef8c84d36843d2
 Date: 2025-06-10T16:18:30-07:00
 
-#process-notes

--- a/docs/main_notes_business_value_research.md
+++ b/docs/main_notes_business_value_research.md
@@ -1,5 +1,6 @@
 # Research Output: Business Value from LiftSim
 
+#process-notes
 random codename: ajar-visit fe771a0e
 
 ***
@@ -103,4 +104,3 @@ In sum, LiftSim’s business relevance comes from its potential to serve as a **
 Commit: 5150480b4bc79fba87833d812b9ff27b7a7f7ba9
 Date: 2025-06-12T10:16:58-07:00
 
-#process-notes

--- a/docs/main_notes_checkpoint_prim_classes.md
+++ b/docs/main_notes_checkpoint_prim_classes.md
@@ -1,5 +1,6 @@
 # Checkpoint - Primary Classes Implemented - pink-walk
 
+#process-notes
 This article (codename `pink-walk 44320cd6`) summarizes the progress made so far in the LiftSim project and outlines immediate next steps.
 
 ## Progress So Far
@@ -20,4 +21,3 @@ The immediate goal is to run a very simple "alpha" simulation that exercises thi
 Commit: 7e5a82fe4c0a267340e3ce7526811a76490a895c
 Date: 2025-06-11T13:29:18-07:00
 
-#process-notes

--- a/docs/main_notes_codex_must_read_this_rules_for_codex.md
+++ b/docs/main_notes_codex_must_read_this_rules_for_codex.md
@@ -1,5 +1,6 @@
 # Project Rules/Conventions for Codex
 
+#process-notes
 This document should help guide codex behavior, i.e. "codex, will you please
 read this and follow as you're editing this codebase". 
 
@@ -33,4 +34,3 @@ be esp sure to follow instructions here: [[zero/999-chaotic/zero-liftsim-docs/wi
 Commit: 29d1fd93b3593a909bd51c980bf2b1d4d33a8310
 Date: 2025-06-12T07:01:38-07:00
 
-#process-notes

--- a/docs/main_notes_development_ref_for_prompts.md
+++ b/docs/main_notes_development_ref_for_prompts.md
@@ -1,5 +1,6 @@
 # Development Reference for Prompts
 
+#process-notes
 random codename: shrill-repeat bfe48d44
 
 
@@ -85,4 +86,3 @@ This file isn’t for rules enforcement or template rigidity. It’s a scratchpa
 Commit: 9f58ae49b8269ba20650e85e0a426975f21c5b84
 Date: 2025-06-12T09:20:22-07:00
 
-#process-notes

--- a/docs/main_notes_devplan.md
+++ b/docs/main_notes_devplan.md
@@ -1,5 +1,6 @@
-Devplan - Current
+# Devplan - Current
 
+#process-notes
 capable-push
 34aa005b-cc44-4778-99c1-c915875bd517
 2025-06-10T16:57:30.568761-06:00
@@ -206,4 +207,3 @@ Let me know when you’re ready to prompt Codex and want help crafting the first
 Commit: c936e3318795d8493c35cb3f8299b583141a5be0
 Date: 2025-06-11T08:52:59-07:00
 
-#process-notes

--- a/docs/main_notes_docstring_style_guide.md
+++ b/docs/main_notes_docstring_style_guide.md
@@ -1,5 +1,6 @@
 # Docstring Style Guide
 
+#process-notes
 **note for codex to read:** this should set the style of all docstrings.
 
 ---
@@ -238,4 +239,3 @@ Each module should include:
 Commit: a3e4945603e0819c1e0372fb6046a4e2d1f48c87
 Date: 2025-06-11T14:34:41-07:00
 
-#process-notes

--- a/docs/main_notes_flowchart.md
+++ b/docs/main_notes_flowchart.md
@@ -1,5 +1,6 @@
 # LiftSim Flowchart
 
+#process-notes
 This diagram illustrates how `zero_liftsim.main` orchestrates a simple, single-lift simulation. The `Simulation` engine executes queued `Event` objects. Agents arrive via `ArrivalEvent`, board using `BoardingEvent`, and the lift completes cycles through `ReturnEvent`.
 
 ```mermaid
@@ -35,4 +36,3 @@ The flow captures the interaction of core classes:
 Commit: c936e3318795d8493c35cb3f8299b583141a5be0
 Date: 2025-06-11T08:52:59-07:00
 
-#process-notes

--- a/docs/main_notes_for_codex_update_toc.md
+++ b/docs/main_notes_for_codex_update_toc.md
@@ -1,11 +1,9 @@
+# codex: Update the Table of Contents
 
-
-
-codex: Update the Table of Contents
-
+#process-notes
 Execute zero-liftsim dev --update-toc to regenerate docs/CONTENTS.md whenever docs are added or renamed.
 # Git Info
+
 Commit: c99211ce71598788a907126ff40a0c9d3c6b8b29
 Date: 2025-06-12T10:56:33-07:00
 
-#process-notes

--- a/docs/main_notes_implementation.md
+++ b/docs/main_notes_implementation.md
@@ -1,5 +1,6 @@
 # Initial Develop Description - Zero Lift Simulator
 
+#process-notes
 ## Overview
 Zero Lift Simulator ("LiftSim") is an agent-based simulation of skier-lift dynamics at a ski resort. The goal is to model individual skier behavior interacting with constrained lift infrastructure over a simulated day. The system is built around an event-driven simulation engine where agents arrive, queue for a single lift, ride, ski down, and repeat.
 
@@ -72,4 +73,3 @@ This document should be included in the repo as a core reference alongside the i
 Commit: c936e3318795d8493c35cb3f8299b583141a5be0
 Date: 2025-06-11T08:52:59-07:00
 
-#process-notes

--- a/docs/main_notes_simulation_manager_tutorial.md
+++ b/docs/main_notes_simulation_manager_tutorial.md
@@ -1,4 +1,6 @@
 # Using SimulationManager
+
+#process-notes
 random codename: animated-event e6b82433
 ***
 The `SimulationManager` class orchestrates configuration and execution
@@ -19,4 +21,3 @@ print(result)
 The returned dictionary matches ``run_alpha_sim`` but ``SimulationManager``
 exposes additional helpers like :py:meth:`archive_agent_rideloop_experience`.
 
-#process-notes

--- a/docs/main_notes_styleguide_wiki_articles.md
+++ b/docs/main_notes_styleguide_wiki_articles.md
@@ -1,5 +1,6 @@
 # Styleguide for Wiki Articles
 
+#process-notes
 random codename: robust-application a24d9a19
 
 
@@ -112,4 +113,3 @@ When documenting code, use fenced code comments to include metadata (especially 
 Commit: 7ece82eb85482921db107f9a7df8c379e2313409
 Date: 2025-06-12T06:40:57-07:00
 
-#process-notes

--- a/docs/main_notes_wiki_article_creation_for_codex.md
+++ b/docs/main_notes_wiki_article_creation_for_codex.md
@@ -1,5 +1,6 @@
 # Wiki Article Creation Instructions for Codex
 
+#process-notes
 random codename: humorous-emphasis ea38febd
 
 ***
@@ -21,4 +22,3 @@ also, whenever you update or create any `md` file in "docs/", the last thing bef
 Commit: 29d1fd93b3593a909bd51c980bf2b1d4d33a8310
 Date: 2025-06-12T07:01:38-07:00
 
-#process-notes

--- a/docs/main_notes_wiki_article_template.md
+++ b/docs/main_notes_wiki_article_template.md
@@ -1,5 +1,6 @@
 # Wiki Article Template - Article Title Here
 
+#process-notes
 _A brief introductory paragraph._
 
 ## Section 1
@@ -13,4 +14,3 @@ Add more details or examples in additional sections as needed.
 Commit: 1b3bf669fde173b2c5f630523fef8c84d36843d2
 Date: 2025-06-10T16:18:30-07:00
 
-#process-notes

--- a/docs/prompt0_dev_init_class.md
+++ b/docs/prompt0_dev_init_class.md
@@ -1,5 +1,6 @@
-prompt0 - simulation class 
+# prompt0 - simulation class 
 
+#prompt
 random codname: 
 
 ```copy
@@ -45,5 +46,6 @@ Follow the “Best Practices for Coding with Codex” guide in docs/best_practic
 
 With these steps you will create a minimal but functional simulation engine to support the other classes.
 # Git Info
+
 Commit: c936e3318795d8493c35cb3f8299b583141a5be0
 Date: 2025-06-11T08:52:59-07:00

--- a/docs/prompt10_multi_lift_sim.md
+++ b/docs/prompt10_multi_lift_sim.md
@@ -1,5 +1,6 @@
 # prompt10 - Implement Multi-Lift Setup stimulating-divide 3437c905
 
+#prompt
 random codename: stimulating-divide 3437c905
 
 *** 

--- a/docs/prompt11_variable_chairs.md
+++ b/docs/prompt11_variable_chairs.md
@@ -1,5 +1,6 @@
-prompt11 - variable chair count
+# prompt11 - variable chair count
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt12_lonely_camera_125058f3.md
+++ b/docs/prompt12_lonely_camera_125058f3.md
@@ -1,5 +1,6 @@
 # prompt12 - state diagram dev lonely-camera 125058f3
 
+#prompt
 random codename: lonely-camera 125058f3
 
 ***

--- a/docs/prompt13_pandas_custom.md
+++ b/docs/prompt13_pandas_custom.md
@@ -1,5 +1,6 @@
 # prompt13 - Integrate .zero pandas custom accessor
 
+#prompt
 amused-medium 8ca7de1e
 
 ***

--- a/docs/prompt14_agent_explicit_fail_aggressive_week.md
+++ b/docs/prompt14_agent_explicit_fail_aggressive_week.md
@@ -1,5 +1,6 @@
 # prompt14 - Force Agent State Map unnamed aggressive-week 801baa1b
 
+#prompt
 random codename: aggressive-week 801baa1b
 
 ***

--- a/docs/prompt1_implement_lift.md
+++ b/docs/prompt1_implement_lift.md
@@ -1,5 +1,6 @@
-prompt1 - lift class 
+# prompt1 - lift class 
 
+#prompt
 random codname: 
 
 ```copy

--- a/docs/prompt2_event_classes.md
+++ b/docs/prompt2_event_classes.md
@@ -1,5 +1,6 @@
-prompt2 - event classes 
+# prompt2 - event classes 
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt3_agent_class.md
+++ b/docs/prompt3_agent_class.md
@@ -1,5 +1,6 @@
-prompt3 - agent class
+# prompt3 - agent class
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt4_implement_alpha_sim.md
+++ b/docs/prompt4_implement_alpha_sim.md
@@ -1,5 +1,6 @@
-prompt4 - alpha simulation and logging
+# prompt4 - alpha simulation and logging
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt5_full_agent_logging.md
+++ b/docs/prompt5_full_agent_logging.md
@@ -1,5 +1,6 @@
-prompt5 - full agent logging
+# prompt5 - full agent logging
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt6_agent_logging.md
+++ b/docs/prompt6_agent_logging.md
@@ -1,5 +1,6 @@
-prompt6 - agent logging
+# prompt6 - agent logging
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt7_simulation_datetime.md
+++ b/docs/prompt7_simulation_datetime.md
@@ -1,5 +1,6 @@
-prompt7 - simulation datetime logging
+# prompt7 - simulation datetime logging
 
+#prompt
 random codname:
 
 ```copy

--- a/docs/prompt8_time_distribution_enhancement.md
+++ b/docs/prompt8_time_distribution_enhancement.md
@@ -1,5 +1,6 @@
 # prompt8 - Implement AgentExperience class
 
+#prompt
 random codename: spurious-action 9169a44e
 
 ***

--- a/docs/prompt9_clock_simulation_runtime.md
+++ b/docs/prompt9_clock_simulation_runtime.md
@@ -1,5 +1,6 @@
 # prompt9 - clock simulation runtime
 
+#prompt
 random codename:
 
 ```copy


### PR DESCRIPTION
## Summary
- categorize docs using tags instead of filenames
- add `#prompt` or `#process-notes` tags after each heading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684d9615de1883239e6e94ba04c8920e