### PR TITLE
Implement agent traceback feature

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -86,3 +86,15 @@ def test_get_latest_event_unrecognized_event():
     agent.activity_log[0] = {"time": ts.isoformat(), "event": "foo"}
     assert agent.get_latest_event(ts) == "foo"
 
+
+def test_traceback_experience_returns_summary():
+    agent = Agent(8)
+    dt = datetime(2025, 6, 14, 9, 0, 0)
+    agent.experience_rideloop.add_entry(agent, "ret", dt, 5, 2, 3)
+    info = next(iter(agent.experience_rideloop.log.values()))
+    exp_id = info["exp_id"]
+    summary = agent.traceback_experience(exp_id)
+    assert str(exp_id) in summary
+    assert "time_spent_in_queue" in summary
+    with pytest.raises(KeyError):
+        agent.traceback_experience("does-not-exist")

--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -137,5 +137,36 @@ class Agent:
 
         return latest_event
 
+    def traceback_experience(self, experience_id: str) -> str:
+        """Return a formatted summary for the given experience.
+
+        Parameters
+        ----------
+        experience_id : str
+            Identifier of the experience entry to summarize.
+
+        Returns
+        -------
+        str
+            Rendered text describing the experience.
+
+        Raises
+        ------
+        KeyError
+            If ``experience_id`` does not exist.
+        """
+
+        from .helpers import load_asset_template
+
+        for dt, info in self.experience_rideloop.log.items():
+            if info.get("exp_id") == experience_id:
+                context = {"time": dt.isoformat(), **info}
+                tmpl = load_asset_template("agent-ride-exp.md.j2")
+                if hasattr(tmpl, "render"):
+                    return tmpl.render(**context)
+                return tmpl.format(**context)
+
+        raise KeyError(experience_id)
+
     def __repr__(self) -> str:  # pragma: no cover - convenience
         return f"Agent({self.agent_id}) {self.agent_uuid_codename} {self.agent_uuid}"


### PR DESCRIPTION
## Summary
- implement `Agent.traceback_experience` to render experience summaries
- test the traceback method

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_agent.py::test_traceback_experience_returns_summary -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684da65048fc83238601194c0795f75e