### PR TITLE
Fix traceback_experience test setup

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -91,6 +91,7 @@ def test_traceback_experience_returns_summary():
     agent = Agent(8)
     dt = datetime(2025, 6, 14, 9, 0, 0)
     agent.experience_rideloop.add_entry(agent, "ret", dt, 5, 2, 3)
+    agent.log_event("ride_complete", 0, dt.isoformat(), return_event_uuid="ret")
     info = next(iter(agent.experience_rideloop.log.values()))
     exp_id = info["exp_id"]
     summary = agent.traceback_experience(exp_id)


### PR DESCRIPTION
## Summary
- add a log entry so `recent_agent_log_return_event_uuid` has data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684db93d57a883238accda7ed496c26c