### PR TITLE
Fix imports after sandbox removal

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from zero_liftsim.agent import Agent
-from zero_liftsim.sandbox import (
+from zero_liftsim.agent_state_id import (
     infer_agent_states,
     state_riding_lift,
     state_in_queue,


### PR DESCRIPTION
## Summary
- update sandbox state tests to import from agent_state_id

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684e31b230908323a0efcfdae360c20e