### PR TITLE
Fix agent state circular import

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -51,6 +51,7 @@
 - [Bugfix - Logger Filepath](bugfix_logger_filepath_finish.md)
 - [Bugfix Response - Logger Filepath finish](bugfix_response_logger_filepath_finish.md)
 - [Bugfix - missing riders object](bugfix_riders.md)
+- [Bugfix - Agent state circular import](bugfix_agent_state_circular_import.md)
 - [The Burden of Simulation: Building Trust in Synthetic Behavior](building_trust_simulation.md)
 - [Dev Snippets](dev_snippets.md)
 - [codex: Maintain SimulationManager Documentation](for_codex_simmanager_docs.md)

--- a/docs/bugfix_agent_state_circular_import.md
+++ b/docs/bugfix_agent_state_circular_import.md
@@ -1,0 +1,19 @@
+# Bugfix - Agent state circular import
+
+random codename: nervous-circle 9d2bfa1e
+
+***
+
+Importing ``infer_agent_states`` in ``zero_liftsim.agent`` caused a
+circular dependency when ``zero_liftsim.agent_state_id`` imported the
+``Agent`` class for type checking. During module initialization Python
+tried to load ``Agent`` before ``infer_agent_states`` was defined,
+raising ``ImportError: cannot import name 'Agent'``.
+
+The fix defers importing ``Agent`` until ``infer_agent_states`` executes
+and only imports it for ``TYPE_CHECKING`` at module load time. This keeps
+type hints intact while avoiding the circular import.
+
+# Git Info
+Commit: 41ec1b166f14f28c3e9fd9ef1960a2dee6548990
+Date: 2025-06-16T06:40:21+00:00

--- a/zero_liftsim/agent_state_id.py
+++ b/zero_liftsim/agent_state_id.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Iterable, Dict
+from typing import Iterable, Dict, TYPE_CHECKING, Union
 
 
 class UnknownEventError(Exception):
     """Raised when :func:`infer_agent_states` encounters an unknown event."""
 
-from .agent import Agent
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .agent import Agent
 
 # State constants used when categorizing agents
 state_riding_lift = "riding_lift"
@@ -27,7 +28,7 @@ _EVENT_STATE_MAP = {
 }
 
 def infer_agent_states(
-    agents: Union[Agent, Iterable[Agent]], 
+    agents: Union["Agent", Iterable["Agent"]],
     dt: datetime
 ) -> Dict[str, str]:
     """Categorize agents based on their latest event at a given time.
@@ -52,6 +53,8 @@ def infer_agent_states(
     UnknownEventError
         If an agent's latest event is not recognized.
     """
+    from .agent import Agent
+
     results: Dict[str, str] = {}
     if isinstance(agents, Agent):
         agents = [agents]


### PR DESCRIPTION
## Summary
- avoid import cycle between `agent` and `agent_state_id`
- document the fix
- update docs table of contents

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684fbbe459dc832399955c07720f6765