### PR TITLE
Rename start_wait to enter_queue

### DIFF
--- a/docs/00projectanchor-liftsim-burly-concert-gigantic-analysis-e7cf1ccf.md
+++ b/docs/00projectanchor-liftsim-burly-concert-gigantic-analysis-e7cf1ccf.md
@@ -57,7 +57,8 @@ xxx
 # 🧠 Anchor: rename start_wait – hanging-silly (3/5)
 
 2025-06-15 12:07:59 -0600
-func `Agent.start_wait` has poor naming. this should be named something more substantial and understandable, where can easily understand "okay agent has now entered the start of the line". 
+func `Agent.start_wait` has poor naming. this should be named something more substantial and understandable, where can easily understand "okay agent has now entered the start of the line".
+It has now been renamed to ``enter_queue``.
 [[prompt19_update _func_name-hanging-silly-001b3e58]]
 
 ## Log

--- a/docs/bugfix_riders.md
+++ b/docs/bugfix_riders.md
@@ -22,7 +22,7 @@ _____________________ test_activity_log_enabled_via_events _____________________
         sim = Simulation()
         lift = Lift(capacity=1, cycle_time=5)
         agent = Agent(3)
-        agent.start_wait(0)
+        agent.enter_queue(0)
         sim.schedule(ArrivalEvent(agent, lift), 0)
 >       sim.run()
 

--- a/docs/prompt19_update _func_name-hanging-silly-001b3e58.md
+++ b/docs/prompt19_update _func_name-hanging-silly-001b3e58.md
@@ -2,24 +2,20 @@
 
 random codename: hanging-silly 001b3e58
 
-#prompt 
+#prompt
 
 ***
 
-see this comment here. 
+see this comment here.
 
 ```python
     # """Record when the agent enters the queue."""
-    # TODO - the name of this function should be different, it is 
-    # too hard to infer what that means, would rather say 
-    # "entered queue"
-    def start_wait(self, time: int, timestamp: str) -> None:
+    def enter_queue(self, time: int, timestamp: str) -> None:
         """Record when the agent enters the queue."""
 
         self.wait_start = time
         self.log_event("start_wait", time, timestamp)
-
 ```
 
-
-func `Agent.start_wait` has poor naming. this should be named something more substantial and understandable, where can easily understand "okay agent has now entered the start of the line". 
+The original function name ``start_wait`` was unclear. It has been renamed to
+``enter_queue`` so it's obvious the agent has entered the line.

--- a/docs/prompt3_agent_class.md
+++ b/docs/prompt3_agent_class.md
@@ -21,7 +21,7 @@ Expand them with fields and logic to measure wait times and rides completed.
 - Track when each agent enters the lift queue (`wait_start`).
 - Record the time an agent boards the lift (`board_time`).
 - Maintain a counter of `rides_completed`.
-- Provide a method `start_wait(time)` to set `wait_start`.
+- Provide a method `enter_queue(time)` to set `wait_start`.
 - Provide a method `finish_ride(time)` that updates `rides_completed`, clears
   `boarded`, and returns the wait time for that ride (`time - wait_start`).
 
@@ -29,7 +29,7 @@ Expand them with fields and logic to measure wait times and rides completed.
 
 Add unit tests verifying that:
 
-1. `start_wait` and `finish_ride` correctly compute wait time and increment
+1. `enter_queue` and `finish_ride` correctly compute wait time and increment
    `rides_completed`.
 2. Agents can complete multiple rides with their counters updating as expected.
 

--- a/docs/prompt6_agent_logging.md
+++ b/docs/prompt6_agent_logging.md
@@ -31,7 +31,7 @@ Implement per-agent self-logging so that each agent retains a detailed history o
   - ``ArrivalEvent.execute`` after the agent is enqueued.
   - ``BoardingEvent.execute`` for each agent that boards the lift.
   - ``ReturnEvent.execute`` when each boarded agent finishes a ride (this may require passing the boarded agent list from ``BoardingEvent`` to ``ReturnEvent``).
-  - Inside ``Agent.start_wait`` and ``Agent.finish_ride`` so manual uses also record events.
+  - Inside ``Agent.enter_queue`` and ``Agent.finish_ride`` so manual uses also record events.
 
 ## Accessing logs
 - After ``run_alpha_sim`` or any simulation run, users can examine ``agent.activity_log`` for a chronological history of that agent’s actions.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -12,7 +12,7 @@ from zero_liftsim.lift import Lift
 def test_wait_and_finish_ride():
     agent = Agent(1)
     start = datetime(2025, 3, 12, 9, 0, 0)
-    agent.start_wait(0, start.isoformat())
+    agent.enter_queue(0, start.isoformat())
     agent.boarded = True
     ts = (start + timedelta(minutes=5)).isoformat()
     wait = agent.finish_ride(5, ts)
@@ -24,14 +24,14 @@ def test_wait_and_finish_ride():
 def test_multiple_rides():
     agent = Agent(2)
     start = datetime(2025, 3, 12, 9, 0, 0)
-    agent.start_wait(0, start.isoformat())
+    agent.enter_queue(0, start.isoformat())
     agent.boarded = True
     ts1 = (start + timedelta(minutes=3)).isoformat()
     wait1 = agent.finish_ride(3, ts1)
     assert wait1 == 3
     assert agent.rides_completed == 1
 
-    agent.start_wait(10, (start + timedelta(minutes=10)).isoformat())
+    agent.enter_queue(10, (start + timedelta(minutes=10)).isoformat())
     agent.boarded = True
     ts2 = (start + timedelta(minutes=15)).isoformat()
     wait2 = agent.finish_ride(15, ts2)
@@ -45,7 +45,7 @@ def test_activity_log_enabled_via_events():
     lift.time_spent_ride_lift = lambda: 5
     agent = Agent(3)
     start = datetime(2025, 3, 12, 9, 0, 0)
-    agent.start_wait(0, start.isoformat())
+    agent.enter_queue(0, start.isoformat())
     sim.schedule(ArrivalEvent(agent, lift), 0)
     sim.run(start_datetime=start)
     events = [entry["event"] for entry in agent.activity_log.values()]
@@ -58,7 +58,7 @@ def test_activity_log_enabled_via_events():
 def test_activity_log_disabled():
     agent = Agent(4, self_logging=False)
     start = datetime(2025, 3, 12, 9, 0, 0)
-    agent.start_wait(0, start.isoformat())
+    agent.enter_queue(0, start.isoformat())
     agent.boarded = True
     agent.finish_ride(5, (start + timedelta(minutes=5)).isoformat())
     assert agent.activity_log == {}

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -18,7 +18,7 @@ import pytest
 def test_infer_agent_states_basic():
     agent = Agent(1)
     start = datetime(2025, 3, 12, 9, 0, 0)
-    agent.start_wait(0, start.isoformat())
+    agent.enter_queue(0, start.isoformat())
     agent.log_event("arrival", 0, start.isoformat())
     agent.log_event("board", 1, (start + timedelta(minutes=1)).isoformat())
 
@@ -31,7 +31,7 @@ def test_infer_agent_states_basic():
     result2 = infer_agent_states([agent], dt2)
     assert result2[agent.agent_uuid] == state_traversing_down
 
-    agent.start_wait(7, (start + timedelta(minutes=7)).isoformat())
+    agent.enter_queue(7, (start + timedelta(minutes=7)).isoformat())
     dt3 = start + timedelta(minutes=8)
     result3 = infer_agent_states([agent], dt3)
     assert result3[agent.agent_uuid] == state_in_queue

--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -123,10 +123,7 @@ class Agent:
 # }}}
 # {{{
     # """Record when the agent enters the queue."""
-    # TODO - the name of this function should be different, it is 
-    # too hard to infer what that means, would rather say 
-    # "entered queue"
-    def start_wait(self, time: int, timestamp: str) -> None:
+    def enter_queue(self, time: int, timestamp: str) -> None:
         """Record when the agent enters the queue."""
 
         self.wait_start = time

--- a/zero_liftsim/events.py
+++ b/zero_liftsim/events.py
@@ -165,7 +165,7 @@ class ReturnEvent(Event):
                     simulation.start_datetime
                     + timedelta(minutes=next_arrival)
                 ).isoformat()
-                agent.start_wait(next_arrival, ts)
+                agent.enter_queue(next_arrival, ts)
                 events.append((ArrivalEvent(agent, self.lift), next_arrival))
         self.lift.chair_return(self.boarded)
         for agent in self.boarded:

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -77,7 +77,7 @@ class SimulationManager:
         for i, agent in enumerate(self.agents):
             self.arrival_times.append(i)
             ts = (self.start_datetime + timedelta(minutes=i)).isoformat()
-            agent.start_wait(i, ts)
+            agent.enter_queue(i, ts)
             self.sim.schedule(ArrivalEvent(agent, self.lift), i)
 
     def run(


### PR DESCRIPTION
## Summary
- rename `Agent.start_wait` to `enter_queue`
- update usages in code and tests
- document new name in related docs

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850cd231d988323a74bfa767da34cad