### PR TITLE
Fix wait time tracking and docs prompt tag

### DIFF
--- a/docs/prompt20_breakable_scratch-689c423e.md
+++ b/docs/prompt20_breakable_scratch-689c423e.md
@@ -3,6 +3,7 @@
 random codename: breakable-scratch 689c423e
 
 ***
+#prompt
 
 
 below is an error of some sort. I guessing this is something trivial. apply a fix. if it 

--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -125,8 +125,9 @@ class Agent:
     def enter_queue(self, time: int, timestamp: str) -> None:
 # {{{
         """Record when the agent enters the queue."""
-        # TODO - codex: the entire phrase "start_wait" is ambigious. use 
+        # TODO - codex: the entire phrase "start_wait" is ambigious. use
         # less ambiguous language.
+        self.wait_start = time
         self.log_event("start_wait", time, timestamp)
 # }}}
     # Mark the ride complete and return wait time."""


### PR DESCRIPTION
## Summary
- ensure `enter_queue` records `wait_start` time
- mark `prompt20_breakable_scratch` as a prompt article

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850d7f305dc83239a88246e544a122a