### PR TITLE
Add Sphinx docs build

### DIFF
--- a/docs-src/Makefile
+++ b/docs-src/Makefile
@@ -1,0 +1,7 @@
+SPHINXBUILD = sphinx-build
+SOURCEDIR = .
+BUILDDIR = ../docs-site
+
+.PHONY: html
+html:
+$(SPHINXBUILD) -b html $(SOURCEDIR) $(BUILDDIR)

--- a/docs-src/api/index.rst
+++ b/docs-src/api/index.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   *

--- a/docs-src/conf.py
+++ b/docs-src/conf.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+project = 'Zero Lift Simulator'
+author = 'Zero Lift'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'myst_parser',
+]
+
+html_theme = 'furo'
+
+source_suffix = {'.rst': 'restructuredtext', '.md': 'markdown'}
+
+templates_path = ['_templates']
+exclude_patterns = []
+html_static_path = ['_static']
+

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,0 +1,8 @@
+# Zero Lift Simulator Documentation
+
+```{toctree}
+:maxdepth: 2
+
+wiki/index
+api/index
+```

--- a/docs-src/wiki/index.md
+++ b/docs-src/wiki/index.md
@@ -1,0 +1,8 @@
+# Wiki
+
+```{toctree}
+:maxdepth: 1
+:glob:
+
+*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "pytest",
     "pandas",
     "matplotlib",
+    "sphinx",
+    "furo",
+    "myst-parser",
 ]
 
 [project.scripts]

--- a/tests/test_docs_tools.py
+++ b/tests/test_docs_tools.py
@@ -14,6 +14,12 @@ def test_cli_parses_new_doc():
     assert args.new_doc
 
 
+def test_cli_parses_build_docs():
+    parser = build_parser()
+    args = parser.parse_args(["dev", "--build-docs"])
+    assert args.build_docs
+
+
 def test_new_doc_creates_file(tmp_path):
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -34,3 +40,4 @@ def test_generate_docs_toc_includes_all_prompts():
         numbers.append(num)
     assert numbers == sorted(numbers, reverse=True)
     assert len(prompt_lines) >= 10
+

--- a/zero_liftsim/cli.py
+++ b/zero_liftsim/cli.py
@@ -68,6 +68,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Create a blank documentation stub in docs/.",
     )
     dev.add_argument(
+        "--build-docs",
+        action="store_true",
+        help="Build Sphinx documentation.",
+    )
+    dev.add_argument(
         "--docstring-prompt", "-dp",
         action="store_true",
         help="prompt for updating docstring. ",
@@ -121,6 +126,9 @@ def run(args) -> None:
         from . import docs_tools
         docs_tools.new_doc()
         docs_tools.update_toc()
+    if getattr(args, "command", None) == "dev" and args.build_docs:
+        from . import docs_tools
+        docs_tools.build_docs()
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation


### PR DESCRIPTION
## Summary
- setup minimal Sphinx project under `docs-src`
- add docs build helper and CLI option `--build-docs`
- generate API docs and include Markdown wiki pages
- add dependencies for Sphinx
- test CLI parser for new flag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6850db51705c83239c0a7b0245091276