### PR TITLE
Fix generate_prompts_index ordering

### DIFF
--- a/zero_liftsim/docs_tools.py
+++ b/zero_liftsim/docs_tools.py
@@ -116,7 +116,6 @@ def generate_prompts_index(*, docs_dir: Path, target_dir: Path) -> None:
         "================",
         "",
         ".. toctree::",
-        "   :maxdepth: 1",
         "",
     ]
     for path in prompt_paths:


### PR DESCRIPTION
## Summary
- remove `:maxdepth:` from generated prompt index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851cdffb5e88323a4c2d76ac3fe4289