### PR TITLE
Implement deterministic simulation seed

### DIFF
--- a/tests/test_replicable_simulation.py
+++ b/tests/test_replicable_simulation.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+from uuid import uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.helpers import base_config
+from zero_liftsim.simmanager import SimulationManager
+
+
+def _run_states(sim_uuid: str):
+    cfg = base_config(Simulation={"__init__": {"simulation_uuid": sim_uuid}})
+    cfg["SimulationManager"]["__init__"].update(
+        {"n_agents": 1, "lift_capacity": 1, "start_datetime": datetime(2025, 3, 12, 9, 0, 0)}
+    )
+    manager = SimulationManager(cfg)
+    manager.run(runtime_minutes=120)
+    agent = manager.agents[0]
+    data = [agent.get_state(t) for t in range(30)]
+    return data
+
+
+def test_simulation_replicates_with_seed():
+    sim_uuid = str(uuid4())
+    states1 = _run_states(sim_uuid)
+    states2 = _run_states(sim_uuid)
+    assert states1 == states2
+

--- a/zero_liftsim/helpers.py
+++ b/zero_liftsim/helpers.py
@@ -49,6 +49,29 @@ def codename():
     return {'uuid':i, 'name':cd(i)}
 
 
+def seed_from_uuid(value: str) -> int:
+    """Return a deterministic integer seed derived from ``value``.
+
+    Parameters
+    ----------
+    value:
+        UUID string used to derive the seed.
+
+    Returns
+    -------
+    int
+        Integer representation of the UUID truncated to 32 bits.
+    """
+    from uuid import UUID
+
+    try:
+        uid = UUID(value)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise ValueError("invalid uuid string") from exc
+
+    return uid.int & 0xFFFFFFFF
+
+
 def load_asset_template(name: str):
     """Load a jinja2 template bundled in ``assets``.
 
@@ -113,6 +136,7 @@ def base_config(**overrides: Any) -> Dict[str, Any]:
             "run": _defaults_from_callable(SimulationManager.run),
         },
         "Simulation": {
+            "__init__": _defaults_from_callable(Simulation.__init__),
             "run": _defaults_from_callable(Simulation.run),
         },
         "Lift": _defaults_from_callable(Lift.__init__),

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -12,6 +12,7 @@ from zero_liftsim.agent import Agent
 from zero_liftsim.events import ArrivalEvent, BoardingEvent, ReturnEvent
 from zero_liftsim.lift import Lift
 from zero_liftsim.logging import Logger
+from zero_liftsim.helpers import seed_from_uuid
 
 
 class SimulationManager:
@@ -54,6 +55,7 @@ class SimulationManager:
 
         self._run_cfg = config.get("SimulationManager", {}).get("run", {})
         self._sim_cfg = config.get("Simulation", {}).get("run", {})
+        self._sim_init_cfg = config.get("Simulation", {}).get("__init__", {})
         self._lift_cfg = config.get("Lift", {})
         self._agent_cfg = config.get("Agent", {}).get("__init__", {})
 
@@ -64,7 +66,7 @@ class SimulationManager:
         self.agent_exp_log_data = {}
 
     def _setup(self) -> None:
-        self.sim = Simulation()
+        self.sim = Simulation(**self._sim_init_cfg)
         num_chairs = self._lift_cfg.get("num_chairs", 50)
         self.lift = Lift(self.lift_capacity, num_chairs)
         for attr in ("ride_mean", "ride_sd", "traverse_mean", "traverse_sd"):
@@ -124,6 +126,7 @@ class SimulationManager:
             logger=self.logger,
             full_agent_logging=self._sim_cfg.get("full_agent_logging", False),
             start_datetime=self.start_datetime,
+            random_seed=seed_from_uuid(self.sim.simulation_uuid),
         )
         total_wait = 0.0
         total_rides = 0

--- a/zero_liftsim/simulation.py
+++ b/zero_liftsim/simulation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import heapq
 from uuid import uuid4 as uuid
+import random
 from datetime import datetime, timedelta
 
 try:
@@ -20,13 +21,13 @@ from .events import Event, ArrivalEvent, BoardingEvent, ReturnEvent
 class Simulation:
     """Discrete-event simulation engine."""
 
-    def __init__(self) -> None:
+    def __init__(self, simulation_uuid: str | None = None) -> None:
         self.current_time: int = 0
         self._counter: int = 0
         self._queue: list[tuple[int, int, Event]] = []
         self._agent_logger: Logger | None = None
         self._agent_records: list[dict] = []
-        self.simulation_uuid = str(uuid())
+        self.simulation_uuid = simulation_uuid or str(uuid())
         self.simulation_codename = codenamize(self.simulation_uuid)
         self.stop_time: int | None = None
 
@@ -42,9 +43,12 @@ class Simulation:
         *,
         full_agent_logging: bool = False,
         start_datetime: datetime = datetime(2025, 3, 12, 9, 0, 0),
+        random_seed: int | None = None,
     ) -> None:
         """Execute scheduled events."""
         self.start_datetime = start_datetime
+        if random_seed is not None:
+            random.seed(random_seed)
         self.stop_time = stop_time
         if full_agent_logging:
             self._agent_logger = Logger("agent.log")


### PR DESCRIPTION
## Summary
- add helper `seed_from_uuid` to derive integer seeds
- allow `Simulation` to accept a UUID and seed random module during `run`
- update `SimulationManager` to pass this seed automatically
- expand config defaults to include `Simulation.__init__`
- test that simulation output reproduces with same seed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68523e29f35083238de12ab466071970