### PR TITLE
Fix agent time bounds check

### DIFF
--- a/zero_liftsim/agent.py
+++ b/zero_liftsim/agent.py
@@ -298,7 +298,7 @@ class Agent:
         """Raise exception if given time not within bounds of act log"""
         df = self.get_activity_log_df()
         msg = 'given time should be within limits'
-        assert time >= df['time'].min() and time <= df['time'].max(), msg
+        assert time >= df['time_offset'].min() and time <= df['time_offset'].max(), msg
 # }}}
 
     def get_rideloop_experience_log_df(self):


### PR DESCRIPTION
## Summary
- check activity log boundaries using `time_offset`

## Testing
- `python -m pytest tests/test_replicable_simulation.py::test_simulation_replicates_with_seed -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852c38ce5048323a3a7700afa17a36d