### PR TITLE
Add sandbox pytest exclusion note

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -76,3 +76,4 @@
 - [unnamed lyrical-development efd3227f](unnamed-lyrical-development-efd3227f.md)
 - [unnamed steady-exit e6ebfe98](unnamed-steady-exit-e6ebfe98.md)
 - [Updating Dependencies](updating_dependencies.md)
+- [Sandbox Pytest Exclusion](aberrant-prize-47d02ecb.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Welcome to the project wiki. Navigate using the links below:
 - [Running the Alpha Simulation](alpha_sim_usage.md)
 
 - [Project Questions](project_questions_orange.md)
+- [Sandbox Pytest Exclusion](aberrant-prize-47d02ecb.md)
 # Git Info
 Commit: 29d1fd93b3593a909bd51c980bf2b1d4d33a8310
 Date: 2025-06-12T07:01:38-07:00

--- a/docs/aberrant-prize-47d02ecb.md
+++ b/docs/aberrant-prize-47d02ecb.md
@@ -1,0 +1,9 @@
+# Sandbox Pytest Exclusion
+
+random codename: aberrant-prize-47d02ecb
+
+Keep sandbox code out of pytest automation. The sandbox module is for development and experimentation only. Integrating it into the automated test suite slows down iteration and complicates maintenance.
+
+# Git Info
+Commit: dd595752b3f771b72fd52dfef78dd31b0786425b
+Date: 2025-06-18T16:55:07+00:00


### PR DESCRIPTION
## Summary
- add doc `aberrant-prize-47d02ecb.md` reminding to exclude the sandbox module from automated tests
- link the new note from README and CONTENTS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas==1.5.3 numpy==2.3.0 python-dateutil==2.9.0.post0 pytz==2025.2` *(fails: operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6852dbacafd8832390c4cb5953c841d8