### PR TITLE
Add estimator doc and sklearn-like API

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -15,6 +15,7 @@
 - [codex: Update the Table of Contents](main_notes_for_codex_update_toc.md)
 - [Initial Develop Description - Zero Lift Simulator](main_notes_implementation.md)
 - [Using SimulationManager](main_notes_simulation_manager_tutorial.md)
+- [Scikit-Learn Estimator Structure](scikit_learn_estimator_structure.md)
 - [Styleguide for Wiki Articles](main_notes_styleguide_wiki_articles.md)
 - [Wiki Article Creation Instructions for Codex](main_notes_wiki_article_creation_for_codex.md)
 - [Wiki Article Template - Article Title Here](main_notes_wiki_article_template.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the project wiki. Navigate using the links below:
 - [Prompt4 Alpha Simulation and Logging](prompt4_implement_alpha_sim.md)
 - [Checkpoint - Primary Classes Implemented - pink-walk](main_notes_checkpoint_prim_classes.md)
 - [Running the Alpha Simulation](alpha_sim_usage.md)
+- [Scikit-Learn Estimator Structure](scikit_learn_estimator_structure.md)
 
 - [Project Questions](project_questions_orange.md)
 - [Sandbox Pytest Exclusion](aberrant-prize-47d02ecb.md)

--- a/docs/scikit_learn_estimator_structure.md
+++ b/docs/scikit_learn_estimator_structure.md
@@ -1,0 +1,7 @@
+In scikit-learn, the model structure follows a very consistent object-oriented design based on *estimators*. An estimator is any object that learns from data—it could be a classifier, regressor, transformer, or pipeline. All estimators implement a common API: you initialize them with parameters (no data), fit them to data with `.fit()`, and then use `.predict()` (for supervised models), `.transform()` (for transformers), or `.predict_proba()` (for probabilistic outputs). This API lets you chain models together and work in a consistent way regardless of the underlying algorithm.
+
+Internally, an estimator class has a defined `__init__()` that stores the hyperparameters you provide. When you call `.fit(X, y)`, the object learns from the data and stores results in attributes ending in an underscore, such as `coef_` or `feature_importances_`. These attributes are then used in `.predict()` or `.transform()`. Importantly, the structure is stateless across function calls: `.fit()` returns `self` so you can chain calls, but each call builds or updates the model in-place.
+
+Because the structure is standardized, scikit-learn makes it easy to combine models in `Pipeline`, tune hyperparameters with `GridSearchCV` or `RandomizedSearchCV`, and do cross-validation with tools like `cross_val_score`. The core idea is that an estimator is a plain Python object with consistent method names and attributes that you can mix and match across different tasks.
+
+This project aims to create methods that look a lot like scikit-learn ways of doing things.

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -135,7 +135,36 @@ class SimulationManager:
             for info in agent.experience_rideloop.log.values():
                 total_wait += info["time_spent_in_queue"]
         avg_wait = total_wait / total_rides if total_rides > 0 else 0
+
         return {"total_rides": total_rides, "average_wait": avg_wait, "agents": self.agents}
+
+    # sklearn-style API --------------------------------------------------
+    def fit(
+        self,
+        *,
+        end_datetime: datetime | None = None,
+        runtime_minutes: int | None = None,
+    ) -> "SimulationManager":
+        """Run the simulation and store results on the instance.
+
+        Returns
+        -------
+        SimulationManager
+            ``self`` for method chaining.
+        """
+
+        self.results_ = self.run(
+            end_datetime=end_datetime,
+            runtime_minutes=runtime_minutes,
+        )
+        return self
+
+    def predict(self, X=None):
+        """Return results from the most recent :meth:`fit` call."""
+
+        if not hasattr(self, "results_"):
+            raise RuntimeError("SimulationManager.fit must be called before predict")
+        return self.results_
 
     def sample_agent(self):
         """Get a simple random sample of agents"""


### PR DESCRIPTION
## Summary
- document scikit-learn estimator pattern
- expose `fit`/`predict` in `SimulationManager`
- reference new doc in wiki contents

## Testing
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853919322dc8323bafdba6eb67d6bd9