### PR TITLE
Respect random_seed config

### DIFF
--- a/tests/test_random_seed.py
+++ b/tests/test_random_seed.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from zero_liftsim.helpers import base_config
+from zero_liftsim.simmanager import SimulationManager
+
+
+def _run_wait(seed):
+    cfg = base_config(Simulation={"run": {"random_seed": seed}})
+    cfg["SimulationManager"]["__init__"].update({"n_agents": 3, "lift_capacity": 2})
+    manager = SimulationManager(cfg)
+    result = manager.run(runtime_minutes=60)
+    return result["average_wait"]
+
+
+def test_simulation_replicates_with_random_seed():
+    seed = str(uuid4())
+    wait1 = _run_wait(seed)
+    wait2 = _run_wait(seed)
+    assert wait1 == wait2

--- a/zero_liftsim/sandbox.py
+++ b/zero_liftsim/sandbox.py
@@ -1,5 +1,8 @@
 """Sandbox dev scratchpad"""
-from zero_helpers.imports import *
+try:  # optional dependency for convenience functions
+    from zero_helpers.imports import *  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - allow running without package
+    pass
 from codenamize import codenamize as cd
 import json
 from copy import deepcopy as copy

--- a/zero_liftsim/simmanager.py
+++ b/zero_liftsim/simmanager.py
@@ -121,12 +121,17 @@ class SimulationManager:
                 end_datetime = default_end
             runtime_minutes = int((end_datetime - self.start_datetime).total_seconds() // 60)
         stop = runtime_minutes
+        seed = self._sim_cfg.get("random_seed")
+        if isinstance(seed, str):
+            seed = seed_from_uuid(seed)
+        elif seed is None:
+            seed = seed_from_uuid(self.sim.simulation_uuid)
         self.sim.run(
             stop_time=stop,
             logger=self.logger,
             full_agent_logging=self._sim_cfg.get("full_agent_logging", False),
             start_datetime=self.start_datetime,
-            random_seed=seed_from_uuid(self.sim.simulation_uuid),
+            random_seed=seed,
         )
         total_wait = 0.0
         total_rides = 0


### PR DESCRIPTION
## Summary
- allow `sandbox.py` to run without optional `zero_helpers`
- honor `Simulation.run.random_seed` if provided in the config
- add regression test for deterministic results using a seed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b9baba3883238d97cdddbea1ce0d